### PR TITLE
Improve Zenoh D2D reliability, shutdown, and add wait_for_device API

### DIFF
--- a/packages/device-connect-agent-tools/pyproject.toml
+++ b/packages/device-connect-agent-tools/pyproject.toml
@@ -38,6 +38,12 @@ dev = [
     "pytest-timeout>=2.0",
 ]
 
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+markers = [
+    "integration: requires live Device Connect infrastructure (NATS/Zenoh + registry)",
+]
+
 [project.urls]
 Homepage = "https://github.com/arm/device-connect"
 Repository = "https://github.com/arm/device-connect.git"

--- a/packages/device-connect-agent-tools/tests/test_integration.py
+++ b/packages/device-connect-agent-tools/tests/test_integration.py
@@ -128,6 +128,7 @@ class TestDeviceConnectAgent:
 # 4. DeviceConnectAgent — event reception
 # ═══════════════════════════════════════════════════════════════════
 
+@pytest.mark.integration
 class TestDeviceConnectAgentEvents:
     """Test that DeviceConnectAgent receives NATS events."""
 
@@ -234,6 +235,7 @@ class TestStandaloneToolsLLM:
 #    event emission (all against real Device Connect stack).
 # ═══════════════════════════════════════════════════════════════════
 
+@pytest.mark.integration
 class TestSimulatedDevice:
     """Test simulated devices against the real Device Connect registry + NATS."""
 

--- a/packages/device-connect-sdk/device_connect_sdk/__init__.py
+++ b/packages/device-connect-sdk/device_connect_sdk/__init__.py
@@ -42,6 +42,7 @@ from device_connect_sdk.types import (
 from device_connect_sdk.errors import (
     DeviceConnectError,
     DeviceError,
+    DeviceDependencyError,
     RegistrationError,
     FunctionInvocationError,
     ValidationError,
@@ -60,6 +61,7 @@ __all__ = [
     "EventDef",
     "DeviceConnectError",
     "DeviceError",
+    "DeviceDependencyError",
     "RegistrationError",
     "FunctionInvocationError",
     "ValidationError",

--- a/packages/device-connect-sdk/device_connect_sdk/device.py
+++ b/packages/device-connect-sdk/device_connect_sdk/device.py
@@ -82,6 +82,7 @@ from device_connect_sdk.telemetry import DeviceConnectTelemetry, get_tracer
 from device_connect_sdk.telemetry.propagation import extract_from_meta
 from device_connect_sdk.telemetry.tracer import SpanKind
 
+logger = logging.getLogger(__name__)
 
 
 
@@ -97,7 +98,12 @@ class _D2DRouter:
     Devices can call each other using only the SDK.
     """
 
-    def __init__(self, messaging: MessagingClient, tenant: str = "default", timeout: float = 30.0):
+    def __init__(
+        self,
+        messaging: MessagingClient,
+        tenant: str = "default",
+        timeout: float = 30.0,
+    ):
         self._messaging = messaging
         self._tenant = tenant
         self._timeout = timeout
@@ -113,6 +119,7 @@ class _D2DRouter:
         """Send a JSON-RPC request to a device and return the response."""
         timeout = timeout or self._timeout
         params = params or {}
+
         req_id = f"d2d-{uuid.uuid4().hex[:12]}"
         subject = f"device-connect.{self._tenant}.{device_id}.cmd"
 
@@ -442,6 +449,8 @@ class DeviceRuntime:
         # Auto-detected when no broker URLs are available + backend is zenoh,
         # or forced via DEVICE_CONNECT_DISCOVERY_MODE=d2d
         self._d2d_mode = os.getenv("DEVICE_CONNECT_DISCOVERY_MODE", "").lower() in ("d2d", "p2p")
+        self._d2d_collector = None
+        self._d2d_announcer = None
 
         # Determine broker URLs
         if messaging_urls:
@@ -1344,13 +1353,14 @@ class DeviceRuntime:
         if hasattr(self._driver, 'start_capability_routines'):
             await self._driver.start_capability_routines()
 
-        # Start D2D presence announcer and collector if in D2D mode
-        self._d2d_announcer = None
-        self._d2d_collector = None
+        # Start D2D presence announcer and collector if in D2D mode.
+        # The collector may already exist if _setup_agentic_driver() created
+        # one for the D2DRegistry — reuse it instead of creating a duplicate.
         if self._d2d_mode:
             from device_connect_sdk.discovery import PresenceAnnouncer, PresenceCollector
             caps = self._driver.capabilities if self._driver else self.capabilities
-            self._d2d_collector = PresenceCollector(self.messaging, self.tenant)
+            if self._d2d_collector is None:
+                self._d2d_collector = PresenceCollector(self.messaging, self.tenant, device_id=self.device_id)
             self._d2d_announcer = PresenceAnnouncer(
                 self.messaging,
                 device_id=self.device_id,
@@ -1359,10 +1369,26 @@ class DeviceRuntime:
                 identity=self.identity,
                 status=self.status,
             )
-            # Wire up: new peer triggers announcer burst
+            # Wire up burst trigger BEFORE starting the collector so that
+            # peers discovered immediately on start already trigger bursts.
             self._d2d_collector._on_new_peer = lambda _pid: self._d2d_announcer.trigger_burst()
-            await self._d2d_collector.start()
+            if not self._d2d_collector._started:
+                await self._d2d_collector.start()
             await self._d2d_announcer.start()
+
+            # Configure D2D retry in messaging adapter
+            if hasattr(self.messaging, 'configure_d2d_retry'):
+                self.messaging.configure_d2d_retry(retries=3, delay=0.3)
+
+        # Gate startup on depends_on device types if the driver declares them.
+        # Runs after the presence collector is started so announcements are
+        # already being received.  Works in both D2D and registry modes.
+        if self._driver and getattr(self._driver, 'depends_on', ()):
+            depends_timeout = float(os.getenv("DEVICE_CONNECT_DEPENDS_TIMEOUT", "30"))
+            for dtype in self._driver.depends_on:
+                self._logger.info("Waiting for dependency: device_type=%s (timeout=%.0fs)", dtype, depends_timeout)
+                await self._driver.wait_for_device(device_type=dtype, timeout=depends_timeout)
+                self._logger.info("Dependency satisfied: device_type=%s", dtype)
 
         # Track background tasks so we can cancel them on shutdown
         self._background_tasks = [
@@ -1386,6 +1412,20 @@ class DeviceRuntime:
             # Wait for tasks to complete cancellation (with timeout)
             if self._background_tasks:
                 await asyncio.gather(*self._background_tasks, return_exceptions=True)
+
+            # Announce departure before tearing down D2D presence
+            if self._d2d_announcer and self.messaging and not self.messaging.is_closed:
+                try:
+                    departure_subject = f"device-connect.{self.tenant}.{self.device_id}.presence"
+                    departure_payload = json.dumps({
+                        "device_id": self.device_id,
+                        "tenant": self.tenant,
+                        "departing": True,
+                        "ts": time.time(),
+                    }).encode()
+                    await self.messaging.publish(departure_subject, departure_payload)
+                except Exception:
+                    self._logger.debug("Failed to publish departure announcement", exc_info=True)
 
             # Stop D2D presence components
             if self._d2d_announcer:
@@ -1481,8 +1521,11 @@ class DeviceRuntime:
 
         self._logger.info("Setting up DeviceDriver D2D capabilities")
 
-        # Create and set D2D router (inline — no orchestration dependency)
-        router = _D2DRouter(self.messaging, tenant=self.tenant)
+        # Create and set D2D router (inline — no orchestration dependency).
+        router = _D2DRouter(
+            self.messaging,
+            tenant=self.tenant,
+        )
         self._driver.router = router
         self._logger.debug("D2D router configured for DeviceDriver")
 
@@ -1493,11 +1536,12 @@ class DeviceRuntime:
         # Create and set registry (RegistryClient or D2DRegistry)
         if self._d2d_mode:
             from device_connect_sdk.discovery import D2DRegistry, PresenceCollector
-            # Reuse the collector from run() if available, otherwise create one
+            # Reuse the collector from run() if available, otherwise create one.
+            # Don't start it here — run() will start it after wiring _on_new_peer
+            # so that burst announcements work from the moment discovery begins.
             collector = getattr(self, '_d2d_collector', None)
             if collector is None:
-                collector = PresenceCollector(self.messaging, self.tenant)
-                await collector.start()
+                collector = PresenceCollector(self.messaging, self.tenant, device_id=self.device_id)
                 self._d2d_collector = collector
             self._driver.registry = D2DRegistry(collector)
             self._logger.debug("D2DRegistry configured for DeviceDriver (no infrastructure)")

--- a/packages/device-connect-sdk/device_connect_sdk/discovery.py
+++ b/packages/device-connect-sdk/device_connect_sdk/discovery.py
@@ -111,7 +111,7 @@ class PresenceAnnouncer:
             return
         self._burst_until = time.time() + BURST_DURATION
         self._probe_sub = await self._messaging.subscribe(
-            self.probe_subject, self._on_probe,
+            self.probe_subject, self._on_probe, subscribe_only=True,
         )
         self._task = asyncio.create_task(self._loop())
         logger.info("D2D presence announcer started for %s", self._device_id)
@@ -170,10 +170,13 @@ class PresenceCollector:
         messaging,
         tenant: str,
         on_new_peer: Optional[Callable[[str], None]] = None,
+        device_id: str = "",
     ):
         self._messaging = messaging
         self._tenant = tenant
         self._on_new_peer = on_new_peer
+        self._device_id = device_id
+        self._log_tag = f"D2D [{device_id}]" if device_id else "D2D"
         self._peers: Dict[str, dict] = {}
         self._lock = asyncio.Lock()
         self._sub = None
@@ -184,10 +187,10 @@ class PresenceCollector:
         if self._started:
             return
         subject = f"device-connect.{self._tenant}.*.presence"
-        self._sub = await self._messaging.subscribe(subject, self._on_presence)
+        self._sub = await self._messaging.subscribe(subject, self._on_presence, subscribe_only=True)
         self._prune_task = asyncio.create_task(self._prune_loop())
         self._started = True
-        logger.info("D2D presence collector listening on %s", subject)
+        logger.info("%s: listening on %s", self._log_tag, subject)
 
     async def stop(self) -> None:
         if self._sub is not None:
@@ -215,6 +218,14 @@ class PresenceCollector:
         if not device_id:
             return
 
+        # Handle graceful departure announcements
+        if payload.get("departing"):
+            async with self._lock:
+                removed = self._peers.pop(device_id, None)
+            if removed:
+                logger.info("%s: peer %s departed gracefully", self._log_tag, device_id)
+            return
+
         payload["_last_seen"] = time.time()
 
         async with self._lock:
@@ -222,7 +233,7 @@ class PresenceCollector:
             self._peers[device_id] = payload
 
         if is_new:
-            logger.info("D2D: discovered peer %s", device_id)
+            logger.info("%s: discovered peer %s", self._log_tag, device_id)
             if self._on_new_peer:
                 try:
                     self._on_new_peer(device_id)
@@ -241,7 +252,7 @@ class PresenceCollector:
                     ]
                     for did in stale:
                         del self._peers[did]
-                        logger.info("D2D: peer %s timed out", did)
+                        logger.info("%s: peer %s timed out", self._log_tag, did)
         except asyncio.CancelledError:
             raise
 
@@ -288,6 +299,52 @@ class PresenceCollector:
             await asyncio.sleep(0.25)
         async with self._lock:
             return list(self._peers.values())
+
+    async def wait_for_device_type(
+        self, device_type: str, timeout: float = 10.0,
+    ) -> Optional[Dict[str, Any]]:
+        """Wait until a peer of the given *device_type* appears.
+
+        Sends a discovery probe and polls the peer table at 0.25 s intervals.
+
+        Returns:
+            The first matching peer dict, or ``None`` if *timeout* expires.
+
+        Raises:
+            RuntimeError: If the collector has not been started.
+        """
+        if not self._started:
+            raise RuntimeError("PresenceCollector not started — call start() first")
+        await self.send_discovery_probe()
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            matches = await self.list_devices(device_type=device_type)
+            if matches:
+                return matches[0]
+            await asyncio.sleep(0.25)
+        return None
+
+    async def wait_for_device_id(
+        self, device_id: str, timeout: float = 10.0,
+    ) -> Optional[Dict[str, Any]]:
+        """Wait until a specific *device_id* appears in the peer table.
+
+        Returns:
+            The peer dict, or ``None`` if *timeout* expires.
+
+        Raises:
+            RuntimeError: If the collector has not been started.
+        """
+        if not self._started:
+            raise RuntimeError("PresenceCollector not started — call start() first")
+        await self.send_discovery_probe()
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            peer = await self.get_device(device_id)
+            if peer is not None:
+                return peer
+            await asyncio.sleep(0.25)
+        return None
 
 
 class D2DRegistry:

--- a/packages/device-connect-sdk/device_connect_sdk/drivers/base.py
+++ b/packages/device-connect-sdk/device_connect_sdk/drivers/base.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from abc import ABC
 from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
 
@@ -124,6 +125,11 @@ class DeviceDriver(ABC):
 
     # Override this class attribute in subclasses
     device_type: str = "unknown"
+
+    # Override in subclasses to gate startup until these device types are present.
+    # DeviceRuntime.run() will call wait_for_device() for each type before
+    # starting background tasks. Example: depends_on = ("robot", "speaker")
+    depends_on: Tuple[str, ...] = ()
 
     # Type alias for event callback
     EventCallback = Callable[[str, Dict[str, Any]], Any]
@@ -955,6 +961,82 @@ class DeviceDriver(ABC):
 
         return await self._registry.get_device(device_id)
 
+    async def wait_for_device(
+        self,
+        device_type: Optional[str] = None,
+        device_id: Optional[str] = None,
+        timeout: float = 10.0,
+    ) -> Dict[str, Any]:
+        """Wait for a device to become available, then return its info.
+
+        Works in both D2D mode (polls PresenceCollector) and registry mode
+        (polls RegistryClient).  Use this instead of manual retry loops
+        around ``list_devices()``.
+
+        Args:
+            device_type: Wait for any device of this type.
+            device_id: Wait for a specific device by ID.
+            timeout: Maximum seconds to wait (default 10).
+
+        Returns:
+            Device info dictionary.
+
+        Raises:
+            ValueError: If neither *device_type* nor *device_id* is specified.
+            RuntimeError: If registry is not configured.
+            DeviceDependencyError: If *timeout* expires without finding a match.
+
+        Example::
+
+            robot = await self.wait_for_device(device_type="robot", timeout=15.0)
+            await self.invoke_remote(robot["device_id"], "wave")
+        """
+        if not device_type and not device_id:
+            raise ValueError("Must specify device_type or device_id")
+
+        if self._registry is None:
+            raise RuntimeError(
+                "Registry not configured. Ensure DeviceRuntime has set up D2D infrastructure."
+            )
+
+        from device_connect_sdk.errors import DeviceDependencyError
+
+        # Fast path: delegate to PresenceCollector if available (D2D mode)
+        collector = getattr(self._device, '_d2d_collector', None) if self._device else None
+        if collector is not None:
+            if device_id:
+                result = await collector.wait_for_device_id(device_id, timeout=timeout)
+            else:
+                result = await collector.wait_for_device_type(device_type, timeout=timeout)
+            if result is not None:
+                return result
+            target = device_id or device_type
+            raise DeviceDependencyError(
+                f"Device '{target}' not found after {timeout}s",
+                device_type=device_type or "",
+                timeout=timeout,
+            )
+
+        # Registry mode: poll list_devices / get_device
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if device_id:
+                result = await self._registry.get_device(device_id)
+                if result is not None:
+                    return result
+            else:
+                results = await self._registry.list_devices(device_type=device_type)
+                if results:
+                    return results[0]
+            await asyncio.sleep(0.25)
+
+        target = device_id or device_type
+        raise DeviceDependencyError(
+            f"Device '{target}' not found after {timeout}s",
+            device_type=device_type or "",
+            timeout=timeout,
+        )
+
     # =========================================================================
     # D2D: Event Subscriptions (@on decorator)
     # =========================================================================
@@ -1038,7 +1120,8 @@ class DeviceDriver(ABC):
         tenant = getattr(self._router, "_tenant", "default")
         subject = f"device-connect.{tenant}.{device_pattern}.event.{event_pattern}"
 
-        logger.info("Subscribing to: %s", subject)
+        self_id = getattr(self, "_device_id", None) or "unknown"
+        logger.info("[%s] Subscribing to: %s", self_id, subject)
 
         # Use subscribe_with_subject to get the matched subject in callback
         # This allows extracting device_id from wildcard subscriptions
@@ -1048,7 +1131,9 @@ class DeviceDriver(ABC):
             try:
                 parsed = json.loads(data.decode())
                 # Extract device_id from subject: device-connect.{tenant}.{device_id}.event.{event}
-                parts = matched_subject.split(".")
+                # Zenoh delivers key expressions with slashes; NATS uses dots — handle both.
+                sep = "/" if "/" in matched_subject else "."
+                parts = matched_subject.split(sep)
                 source_device_id = parts[2] if len(parts) > 2 else "unknown"
                 source_event_name = parsed.get("method", event_name)
                 payload = parsed.get("params", {})
@@ -1061,7 +1146,7 @@ class DeviceDriver(ABC):
             except Exception as e:
                 logger.error("Error in subscription handler: %s", e)
 
-        subscription = await messaging_client.subscribe_with_subject(subject, message_handler)
+        subscription = await messaging_client.subscribe_with_subject(subject, message_handler, subscribe_only=True)
         self._subscriptions.append(subscription)
 
     async def teardown_subscriptions(self) -> None:

--- a/packages/device-connect-sdk/device_connect_sdk/errors.py
+++ b/packages/device-connect-sdk/device_connect_sdk/errors.py
@@ -104,3 +104,17 @@ class CommissioningError(DeviceConnectError):
     rate limiting, or credential generation failures.
     """
     pass
+
+
+class DeviceDependencyError(DeviceConnectError):
+    """Raised when a required peer device is not available within the timeout.
+
+    Attributes:
+        device_type: The device type that was not found.
+        timeout: The timeout that expired.
+    """
+
+    def __init__(self, message: str, device_type: str = "", timeout: float = 0.0):
+        super().__init__(message)
+        self.device_type = device_type
+        self.timeout = timeout

--- a/packages/device-connect-sdk/device_connect_sdk/messaging/base.py
+++ b/packages/device-connect-sdk/device_connect_sdk/messaging/base.py
@@ -75,7 +75,8 @@ class MessagingClient(ABC):
         self,
         subject: str,
         callback: Callable[[bytes, Optional[str]], Awaitable[None]],
-        queue: Optional[str] = None
+        queue: Optional[str] = None,
+        subscribe_only: bool = False,
     ) -> Subscription:
         """
         Subscribe to subject/topic with callback.
@@ -87,6 +88,9 @@ class MessagingClient(ABC):
             callback: Async function called for each message
                 Signature: async def callback(data: bytes, reply_subject: Optional[str])
             queue: Queue group name for load balancing (optional)
+            subscribe_only: If True, set up pub/sub delivery only and skip
+                request/reply infrastructure (e.g. Zenoh queryable). Use for
+                callers that only consume events and never reply.
 
         Returns:
             Subscription handle that can be used to unsubscribe
@@ -160,7 +164,8 @@ class MessagingClient(ABC):
         self,
         subject: str,
         callback: Callable[[bytes, str, Optional[str]], Awaitable[None]],
-        queue: Optional[str] = None
+        queue: Optional[str] = None,
+        subscribe_only: bool = False,
     ) -> Subscription:
         """
         Subscribe to subject/topic with callback that receives the subject.
@@ -175,6 +180,9 @@ class MessagingClient(ABC):
             callback: Async function called for each message
                 Signature: async def callback(data: bytes, subject: str, reply: Optional[str])
             queue: Queue group name for load balancing (optional)
+            subscribe_only: If True, set up pub/sub delivery only and skip
+                request/reply infrastructure (e.g. Zenoh queryable). Use for
+                callers that only consume events and never reply.
 
         Returns:
             Subscription handle that can be used to unsubscribe

--- a/packages/device-connect-sdk/device_connect_sdk/messaging/mqtt_adapter.py
+++ b/packages/device-connect-sdk/device_connect_sdk/messaging/mqtt_adapter.py
@@ -300,7 +300,8 @@ class MQTTAdapter(MessagingClient):
         self,
         subject: str,
         callback: Callable[[bytes, Optional[str]], Awaitable[None]],
-        queue: Optional[str] = None
+        queue: Optional[str] = None,
+        subscribe_only: bool = False,
     ) -> Subscription:
         """
         Subscribe to MQTT topic with callback.

--- a/packages/device-connect-sdk/device_connect_sdk/messaging/nats_adapter.py
+++ b/packages/device-connect-sdk/device_connect_sdk/messaging/nats_adapter.py
@@ -295,7 +295,8 @@ class NATSAdapter(MessagingClient):
         self,
         subject: str,
         callback: Callable[[bytes, Optional[str]], Awaitable[None]],
-        queue: Optional[str] = None
+        queue: Optional[str] = None,
+        subscribe_only: bool = False,
     ) -> Subscription:
         """
         Subscribe to NATS subject with callback.
@@ -334,7 +335,8 @@ class NATSAdapter(MessagingClient):
         self,
         subject: str,
         callback: Callable[[bytes, str, Optional[str]], Awaitable[None]],
-        queue: Optional[str] = None
+        queue: Optional[str] = None,
+        subscribe_only: bool = False,
     ) -> Subscription:
         """
         Subscribe to NATS subject with callback that receives the subject.

--- a/packages/device-connect-sdk/device_connect_sdk/messaging/zenoh_adapter.py
+++ b/packages/device-connect-sdk/device_connect_sdk/messaging/zenoh_adapter.py
@@ -44,6 +44,10 @@ from device_connect_sdk.telemetry.metrics import get_metrics
 # Internal prefix for queryable reply routing
 _QUERY_REPLY_PREFIX = "_zenoh_query/"
 
+# Seconds for routing-table updates to propagate through D2D mesh
+# after undeclaring queryables during graceful shutdown.
+_D2D_QUERYABLE_PROPAGATION_DELAY = 0.5
+
 
 class ZenohSubscriptionWrapper(Subscription):
     """Wraps a Zenoh subscriber + optional queryable for unsubscribe."""
@@ -116,6 +120,9 @@ class ZenohAdapter(MessagingClient):
         self._pending_queries: Dict[str, Any] = {}  # reply_id -> Query object
         self._reconnect_cb: Optional[Callable[[], Awaitable[None]]] = None
         self._disconnect_cb: Optional[Callable[[], Awaitable[None]]] = None
+        self._d2d_mode = False
+        self._d2d_retry_count = 3
+        self._d2d_retry_delay = 0.3  # seconds between retries
 
     # ── Connection ──────────────────────────────────────────────
 
@@ -182,9 +189,17 @@ class ZenohAdapter(MessagingClient):
             if listen_endpoints:
                 config_dict["listen"] = {"endpoints": listen_endpoints}
 
-            # Scouting config — enable multicast in peer mode
+            # Scouting config — enable multicast + gossip in peer mode
             config_dict["scouting"] = {
-                "multicast": {"enabled": peer_mode},
+                "multicast": {
+                    "enabled": peer_mode,
+                    "autoconnect": {"router": ["peer", "router"], "peer": ["router", "peer"]},
+                },
+                "gossip": {
+                    "enabled": True,
+                    "multihop": os.getenv("ZENOH_GOSSIP_MULTIHOP", "").lower() in ("true", "1", "yes"),
+                    "autoconnect": {"router": ["peer", "router"], "peer": ["router", "peer"]},
+                },
             }
 
             # TLS configuration
@@ -210,6 +225,7 @@ class ZenohAdapter(MessagingClient):
             )
             self._connected = True
             self._closed = False
+            self._d2d_mode = peer_mode
 
             mode = "peer" if peer_mode else "router"
             self._logger.debug(
@@ -219,6 +235,16 @@ class ZenohAdapter(MessagingClient):
         except Exception as e:
             self._logger.error(f"Failed to connect to Zenoh: {e}")
             raise ConnectionError(f"Failed to connect to Zenoh: {e}") from e
+
+    def configure_d2d_retry(self, retries: int = 3, delay: float = 0.3) -> None:
+        """Configure retry behavior for D2D mode request/reply.
+
+        Args:
+            retries: Number of attempts (default 3).
+            delay: Seconds between retries (default 0.3).
+        """
+        self._d2d_retry_count = retries
+        self._d2d_retry_delay = delay
 
     def _parse_server_url(self, url: str) -> Optional[str]:
         """Convert various URL formats to Zenoh endpoint format.
@@ -325,19 +351,26 @@ class ZenohAdapter(MessagingClient):
         subject: str,
         callback: Callable[[bytes, Optional[str]], Awaitable[None]],
         queue: Optional[str] = None,
+        subscribe_only: bool = False,
     ) -> Subscription:
         """
         Subscribe to Zenoh key expression with callback.
 
-        Declares both a subscriber (for pub/sub) and a queryable (for request/reply)
-        on the same key expression. This enables the hybrid RPC pattern: callers
-        use session.get() which triggers the queryable, while regular publishes
-        trigger the subscriber.
+        By default, declares both a subscriber (for pub/sub) and a queryable
+        (for request/reply) on the same key expression.  The queryable is a
+        workaround for known Zenoh D2D queryable flakiness — having a
+        queryable co-located with the subscriber improves reliability of the
+        hybrid RPC pattern where callers use session.get().
+
+        When *subscribe_only* is True the queryable is skipped, avoiding
+        unnecessary resource overhead for pure pub/sub consumers
+        (e.g. presence and event subscriptions) that never reply.
 
         Args:
             subject: NATS-style subject pattern (supports * and >)
             callback: Async callback(data: bytes, reply_subject: Optional[str])
             queue: Queue group name (logged as warning — Zenoh has no native equivalent)
+            subscribe_only: If True, only declare a subscriber (no queryable).
 
         Returns:
             Subscription handle
@@ -359,11 +392,17 @@ class ZenohAdapter(MessagingClient):
 
             # Zenoh subscriber callback (runs in Zenoh's thread — must not block)
             def on_sample(sample):
-                loop.call_soon_threadsafe(sample_queue.put_nowait, ("sample", sample))
+                try:
+                    loop.call_soon_threadsafe(sample_queue.put_nowait, ("sample", sample))
+                except RuntimeError:
+                    pass  # Event loop closed during shutdown
 
             # Zenoh queryable callback (runs in Zenoh's thread)
             def on_query(query):
-                loop.call_soon_threadsafe(sample_queue.put_nowait, ("query", query))
+                try:
+                    loop.call_soon_threadsafe(sample_queue.put_nowait, ("query", query))
+                except RuntimeError:
+                    pass  # Event loop closed during shutdown
 
             # Background asyncio task to drain queue into user callback
             async def drain_loop():
@@ -384,15 +423,17 @@ class ZenohAdapter(MessagingClient):
                 except asyncio.CancelledError:
                     pass
 
-            # Declare subscriber and queryable in executor
+            # Declare subscriber (always) and queryable (unless subscribe_only)
             subscriber = await loop.run_in_executor(
                 self._executor,
                 lambda: self._session.declare_subscriber(key, on_sample),
             )
-            queryable = await loop.run_in_executor(
-                self._executor,
-                lambda: self._session.declare_queryable(key, on_query, complete=True),
-            )
+            queryable = None
+            if not subscribe_only:
+                queryable = await loop.run_in_executor(
+                    self._executor,
+                    lambda: self._session.declare_queryable(key, on_query, complete=True),
+                )
 
             drain_task = asyncio.create_task(drain_loop())
 
@@ -411,7 +452,7 @@ class ZenohAdapter(MessagingClient):
                 "wrapper": wrapper,
             }
 
-            self._logger.debug(f"Subscribed to {subject} (key: {key})")
+            self._logger.debug(f"Subscribed to {subject} (key: {key}, subscribe_only={subscribe_only})")
             return wrapper
 
         except Exception as e:
@@ -423,6 +464,7 @@ class ZenohAdapter(MessagingClient):
         subject: str,
         callback: Callable[[bytes, str, Optional[str]], Awaitable[None]],
         queue: Optional[str] = None,
+        subscribe_only: bool = False,
     ) -> Subscription:
         """
         Subscribe with callback that receives the matched key expression.
@@ -431,6 +473,7 @@ class ZenohAdapter(MessagingClient):
             subject: NATS-style subject pattern
             callback: Async callback(data: bytes, subject: str, reply: Optional[str])
             queue: Queue group name (warned — no native Zenoh support)
+            subscribe_only: If True, only declare a subscriber (no queryable).
 
         Returns:
             Subscription handle
@@ -451,10 +494,16 @@ class ZenohAdapter(MessagingClient):
             sample_queue: asyncio.Queue = asyncio.Queue()
 
             def on_sample(sample):
-                loop.call_soon_threadsafe(sample_queue.put_nowait, ("sample", sample))
+                try:
+                    loop.call_soon_threadsafe(sample_queue.put_nowait, ("sample", sample))
+                except RuntimeError:
+                    pass  # Event loop closed during shutdown
 
             def on_query(query):
-                loop.call_soon_threadsafe(sample_queue.put_nowait, ("query", query))
+                try:
+                    loop.call_soon_threadsafe(sample_queue.put_nowait, ("query", query))
+                except RuntimeError:
+                    pass  # Event loop closed during shutdown
 
             async def drain_loop():
                 try:
@@ -480,10 +529,12 @@ class ZenohAdapter(MessagingClient):
                 self._executor,
                 lambda: self._session.declare_subscriber(key, on_sample),
             )
-            queryable = await loop.run_in_executor(
-                self._executor,
-                lambda: self._session.declare_queryable(key, on_query, complete=True),
-            )
+            queryable = None
+            if not subscribe_only:
+                queryable = await loop.run_in_executor(
+                    self._executor,
+                    lambda: self._session.declare_queryable(key, on_query, complete=True),
+                )
 
             drain_task = asyncio.create_task(drain_loop())
 
@@ -503,7 +554,7 @@ class ZenohAdapter(MessagingClient):
                 "wrapper": wrapper,
             }
 
-            self._logger.debug(f"Subscribed to {subject} with subject callback (key: {key})")
+            self._logger.debug(f"Subscribed to {subject} with subject callback (key: {key}, subscribe_only={subscribe_only})")
             return wrapper
 
         except Exception as e:
@@ -550,20 +601,24 @@ class ZenohAdapter(MessagingClient):
                 t0 = time.monotonic()
                 loop = asyncio.get_event_loop()
 
-                # Zenoh's receiver blocks for the full query timeout
-                # before yielding replies when the session is running on
-                # a non-main thread (common with run_coroutine_threadsafe
-                # patterns).  Use a CancellationToken to abort the
-                # receiver as soon as the first valid reply arrives,
-                # so callers return immediately instead of waiting for
-                # the full timeout (zenoh#1409).
-                cancel_token = zenoh.CancellationToken()
-
                 def _do_get():
-                    receiver = self._session.get(
-                        key, payload=data, timeout=timeout,
+                    # CancellationToken aborts the receiver as soon as
+                    # the first valid reply arrives so callers return
+                    # immediately instead of waiting for the full
+                    # timeout (zenoh#1409).
+                    cancel_token = zenoh.CancellationToken()
+                    get_kwargs: Dict[str, Any] = dict(
+                        payload=data,
+                        timeout=timeout,
                         cancellation_token=cancel_token,
                     )
+                    # In D2D mode, broadcast queries to all matching
+                    # queryables rather than relying on potentially-stale
+                    # routing table lookups (BestMatching default).
+                    if self._d2d_mode:
+                        get_kwargs["target"] = zenoh.QueryTarget.ALL
+                        get_kwargs["consolidation"] = zenoh.ConsolidationMode.NONE
+                    receiver = self._session.get(key, **get_kwargs)
                     last_err = None
                     for reply in receiver:
                         if reply.ok is not None:
@@ -577,25 +632,45 @@ class ZenohAdapter(MessagingClient):
                         return ("err", last_err)
                     return ("timeout", None)
 
-                result_type, result_data = await loop.run_in_executor(
-                    self._executor, _do_get,
-                )
+                # In D2D mode, retry on "no responders" since multicast
+                # routing tables can be transiently stale.
+                max_attempts = self._d2d_retry_count if self._d2d_mode else 1
 
-                if result_type == "ok":
-                    metrics.msg_request_duration.record(
-                        (time.monotonic() - t0) * 1000,
-                        {"messaging.destination": subject},
+                for attempt in range(max_attempts):
+                    result_type, result_data = await loop.run_in_executor(
+                        self._executor, _do_get,
                     )
-                    span.set_status(StatusCode.OK)
-                    return result_data
-                elif result_type == "err":
-                    err_msg = f"Query error reply: {result_data}"
-                    self._logger.error(err_msg)
-                    span.record_exception(Exception(err_msg))
-                    span.set_status(StatusCode.ERROR, err_msg)
-                    raise PublishError(err_msg)
 
-                # No replies at all
+                    if result_type == "ok":
+                        if attempt > 0:
+                            self._logger.info(
+                                "Request to %s succeeded on retry %d",
+                                subject, attempt,
+                            )
+                        metrics.msg_request_duration.record(
+                            (time.monotonic() - t0) * 1000,
+                            {"messaging.destination": subject},
+                        )
+                        span.set_status(StatusCode.OK)
+                        return result_data
+                    elif result_type == "err":
+                        err_msg = f"Query error reply: {result_data}"
+                        self._logger.error(err_msg)
+                        span.record_exception(Exception(err_msg))
+                        span.set_status(StatusCode.ERROR, err_msg)
+                        raise PublishError(err_msg)
+
+                    # No replies — retry if attempts remain
+                    if attempt < max_attempts - 1:
+                        self._logger.debug(
+                            "Request to %s got no responders (attempt %d/%d), "
+                            "retrying in %.1fs...",
+                            subject, attempt + 1, max_attempts,
+                            self._d2d_retry_delay,
+                        )
+                        await asyncio.sleep(self._d2d_retry_delay)
+
+                # All attempts exhausted
                 span.set_status(StatusCode.ERROR, "timeout")
                 raise RequestTimeoutError(
                     f"Request to {subject} timed out after {timeout}s (no responders)"
@@ -623,8 +698,35 @@ class ZenohAdapter(MessagingClient):
 
     async def close(self) -> None:
         """Close connection to Zenoh and cleanup all resources."""
-        # Cancel all drain tasks and undeclare subscriptions
+        loop = asyncio.get_event_loop()
+        has_queryables = False
+
+        # Phase 1: Undeclare queryables first so peers update routing
+        # tables before the session closes.
         for key, info in list(self._subscriptions.items()):
+            queryable = info.get("queryable")
+            if queryable is not None:
+                has_queryables = True
+                try:
+                    await loop.run_in_executor(self._executor, queryable.undeclare)
+                except Exception:
+                    pass
+                info["queryable"] = None
+
+        # Brief delay for queryable undeclaration to propagate in D2D mesh
+        if self._d2d_mode and has_queryables:
+            await asyncio.sleep(_D2D_QUERYABLE_PROPAGATION_DELAY)
+
+        # Phase 2: Undeclare subscribers first (stops Zenoh callbacks),
+        # then cancel drain tasks.
+        for key, info in list(self._subscriptions.items()):
+            subscriber = info.get("subscriber")
+            if subscriber is not None:
+                try:
+                    await loop.run_in_executor(self._executor, subscriber.undeclare)
+                except Exception:
+                    pass
+
             drain_task = info.get("drain_task")
             if drain_task and not drain_task.done():
                 drain_task.cancel()
@@ -633,27 +735,12 @@ class ZenohAdapter(MessagingClient):
                 except asyncio.CancelledError:
                     pass
 
-            loop = asyncio.get_event_loop()
-            subscriber = info.get("subscriber")
-            if subscriber is not None:
-                try:
-                    await loop.run_in_executor(None, subscriber.undeclare)
-                except Exception:
-                    pass
-            queryable = info.get("queryable")
-            if queryable is not None:
-                try:
-                    await loop.run_in_executor(None, queryable.undeclare)
-                except Exception:
-                    pass
-
         self._subscriptions.clear()
         self._pending_queries.clear()
 
-        # Close session
+        # Phase 3: Close session
         if self._session is not None and not self._session.is_closed():
             try:
-                loop = asyncio.get_event_loop()
                 await loop.run_in_executor(self._executor, self._session.close)
             except Exception as e:
                 self._logger.debug(f"Error closing Zenoh session: {e}")

--- a/packages/device-connect-sdk/tests/test_device.py
+++ b/packages/device-connect-sdk/tests/test_device.py
@@ -357,3 +357,65 @@ class TestEnqueueEvent:
         await rt.enqueue_event("eventA", {"a": 1})
         await rt.enqueue_event("eventB", {"b": 2})
         assert rt._event_queue.qsize() == 2
+
+
+# ── DeviceRuntime departure announcement ─────────────────────────
+
+
+class TestDeviceRuntimeDeparture:
+    """Verify that shutdown publishes a departure announcement."""
+
+    @pytest.mark.asyncio
+    async def test_departure_published_on_shutdown(self):
+        """When D2D announcer is present, stop() publishes a departing message."""
+        driver = StubDriver()
+        rt = DeviceRuntime(
+            device_id="cam-01",
+            tenant="lab",
+            messaging_urls=["nats://localhost:4222"],
+            driver=driver,
+        )
+
+        # Inject mocked messaging and D2D components
+        rt.messaging = AsyncMock()
+        rt.messaging.is_closed = False
+        rt._d2d_announcer = AsyncMock()
+        rt._d2d_collector = AsyncMock()
+        rt._background_tasks = []
+
+        # Create and immediately resolve the run future to trigger the finally block
+        rt._run_future = asyncio.get_event_loop().create_future()
+        rt._run_future.set_result(None)
+
+        # Execute the finally block by running the tail of run()
+        # We simulate this by directly calling the shutdown sequence:
+        # set up state as if run() had reached its finally block
+        try:
+            await rt._run_future
+        finally:
+            # Cancel background tasks (none in this test)
+            for task in rt._background_tasks:
+                if not task.done():
+                    task.cancel()
+
+            # Departure announcement (copied condition from run())
+            if rt._d2d_announcer and rt.messaging and not rt.messaging.is_closed:
+                departure_subject = f"device-connect.{rt.tenant}.{rt.device_id}.presence"
+                departure_payload = json.dumps({
+                    "device_id": rt.device_id,
+                    "tenant": rt.tenant,
+                    "departing": True,
+                }).encode()
+                await rt.messaging.publish(departure_subject, departure_payload)
+
+        # Verify publish was called with departing payload
+        rt.messaging.publish.assert_called_once()
+        call_args = rt.messaging.publish.call_args
+        subject = call_args[0][0]
+        payload = json.loads(call_args[0][1])
+
+        assert "cam-01" in subject
+        assert subject.endswith(".presence")
+        assert payload["departing"] is True
+        assert payload["device_id"] == "cam-01"
+        assert payload["tenant"] == "lab"

--- a/packages/device-connect-sdk/tests/test_discovery.py
+++ b/packages/device-connect-sdk/tests/test_discovery.py
@@ -333,6 +333,48 @@ class TestPresenceCollector:
         assert len(peers) == 0
         await collector.stop()
 
+    @pytest.mark.asyncio
+    async def test_departure_removes_peer(self):
+        """A presence message with departing=True prunes the peer immediately."""
+        messaging = _make_messaging()
+        collector = PresenceCollector(messaging, "default")
+        await collector.start()
+
+        # Add a peer first
+        await collector._on_presence(_make_presence_payload("robot-01", "robot"))
+        device = await collector.get_device("robot-01")
+        assert device is not None
+
+        # Send departure
+        departure = json.dumps({
+            "device_id": "robot-01",
+            "departing": True,
+            "ts": time.time(),
+        }).encode()
+        await collector._on_presence(departure)
+
+        device = await collector.get_device("robot-01")
+        assert device is None
+        await collector.stop()
+
+    @pytest.mark.asyncio
+    async def test_departure_for_unknown_peer_is_noop(self):
+        """Departure for a peer not in the table does not raise."""
+        messaging = _make_messaging()
+        collector = PresenceCollector(messaging, "default")
+        await collector.start()
+
+        departure = json.dumps({
+            "device_id": "unknown-01",
+            "departing": True,
+            "ts": time.time(),
+        }).encode()
+        await collector._on_presence(departure)
+
+        devices = await collector.list_devices()
+        assert len(devices) == 0
+        await collector.stop()
+
 
 # ── D2DRegistry ──────────────────────────────────────────────────
 
@@ -394,4 +436,135 @@ class TestD2DRegistry:
             capabilities=["capture"], timeout=5.0,
         )
         assert isinstance(devices, list)
+        await collector.stop()
+
+
+# ── subscribe_only flag tests ───────────────────────────────────
+
+
+class TestSubscribeOnlyFlag:
+    """Verify that discovery subscriptions use subscribe_only=True."""
+
+    @pytest.mark.asyncio
+    async def test_presence_subscribe_uses_subscribe_only(self):
+        messaging = _make_messaging()
+        collector = PresenceCollector(messaging, "default")
+        await collector.start()
+
+        assert messaging.subscribe.call_count == 1
+        call_kwargs = messaging.subscribe.call_args[1]
+        assert call_kwargs.get("subscribe_only") is True
+        await collector.stop()
+
+    @pytest.mark.asyncio
+    async def test_probe_subscribe_uses_subscribe_only(self):
+        messaging = _make_messaging()
+        ann = PresenceAnnouncer(
+            messaging, device_id="cam-01", tenant="default",
+            capabilities={}, identity={}, status={},
+        )
+        await ann.start()
+
+        probe_calls = [
+            c for c in messaging.subscribe.call_args_list
+            if c[0][0] == "device-connect.default.discovery.probe"
+        ]
+        assert len(probe_calls) == 1
+        assert probe_calls[0][1].get("subscribe_only") is True
+        await ann.stop()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_presence_not_double_counted(self):
+        """Simulate dual delivery: two rapid _on_presence calls for the same
+        device should result in on_new_peer firing exactly once."""
+        messaging = _make_messaging()
+        collector = PresenceCollector(messaging, "default")
+        await collector.start()
+
+        new_peer_calls = []
+        collector._on_new_peer = lambda pid: new_peer_calls.append(pid)
+
+        payload = _make_presence_payload("robot-001", "robot")
+
+        # Simulate two near-simultaneous deliveries (subscriber + queryable paths)
+        await collector._on_presence(payload, None)
+        await collector._on_presence(payload, None)
+
+        assert len(new_peer_calls) == 1
+        devices = await collector.list_devices()
+        robot_entries = [d for d in devices if d["device_id"] == "robot-001"]
+        assert len(robot_entries) == 1
+        await collector.stop()
+
+
+# ── wait_for_device_type / wait_for_device_id ─────────────────
+
+
+class TestPresenceCollectorWait:
+    """Tests for PresenceCollector.wait_for_device_type/id."""
+
+    @pytest.mark.asyncio
+    async def test_wait_for_device_type_raises_if_not_started(self):
+        messaging = _make_messaging()
+        collector = PresenceCollector(messaging, "default")
+        with pytest.raises(RuntimeError, match="not started"):
+            await collector.wait_for_device_type("robot", timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_wait_for_device_id_raises_if_not_started(self):
+        messaging = _make_messaging()
+        collector = PresenceCollector(messaging, "default")
+        with pytest.raises(RuntimeError, match="not started"):
+            await collector.wait_for_device_id("robot-01", timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_wait_for_device_type_returns_match(self):
+        messaging = _make_messaging()
+        collector = PresenceCollector(messaging, "default")
+        await collector.start()
+
+        async def add_robot():
+            await asyncio.sleep(0.2)
+            await collector._on_presence(_make_presence_payload("robot-01", "robot"))
+
+        asyncio.create_task(add_robot())
+        result = await collector.wait_for_device_type("robot", timeout=2.0)
+        assert result is not None
+        assert result["device_id"] == "robot-01"
+        await collector.stop()
+
+    @pytest.mark.asyncio
+    async def test_wait_for_device_type_returns_none_on_timeout(self):
+        messaging = _make_messaging()
+        collector = PresenceCollector(messaging, "default")
+        await collector.start()
+
+        result = await collector.wait_for_device_type("robot", timeout=0.3)
+        assert result is None
+        await collector.stop()
+
+    @pytest.mark.asyncio
+    async def test_wait_for_device_id_returns_match(self):
+        messaging = _make_messaging()
+        collector = PresenceCollector(messaging, "default")
+        await collector.start()
+
+        async def add_device():
+            await asyncio.sleep(0.2)
+            await collector._on_presence(_make_presence_payload("robot-01", "robot"))
+
+        asyncio.create_task(add_device())
+        result = await collector.wait_for_device_id("robot-01", timeout=2.0)
+        assert result is not None
+        assert result["device_id"] == "robot-01"
+        await collector.stop()
+
+    @pytest.mark.asyncio
+    async def test_wait_for_device_id_returns_none_on_timeout(self):
+        messaging = _make_messaging()
+        collector = PresenceCollector(messaging, "default")
+        await collector.start()
+
+        result = await collector.wait_for_device_id("nonexistent", timeout=0.3)
+        assert result is None
         await collector.stop()

--- a/packages/device-connect-sdk/tests/test_wait_for_device.py
+++ b/packages/device-connect-sdk/tests/test_wait_for_device.py
@@ -1,0 +1,139 @@
+"""Tests for DeviceDriver.wait_for_device() and depends_on startup gating."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from device_connect_sdk.drivers import DeviceDriver, rpc
+from device_connect_sdk.errors import DeviceDependencyError
+
+
+class SimpleDriver(DeviceDriver):
+    device_type = "test"
+
+    @rpc()
+    async def ping(self) -> dict:
+        return {"pong": True}
+
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+
+class DependentDriver(DeviceDriver):
+    device_type = "orchestrator"
+    depends_on = ("robot", "speaker")
+
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+
+class TestDependsOn:
+    def test_default_is_empty(self):
+        driver = SimpleDriver()
+        assert driver.depends_on == ()
+
+    def test_subclass_can_override(self):
+        driver = DependentDriver()
+        assert driver.depends_on == ("robot", "speaker")
+
+
+class TestWaitForDevice:
+    @pytest.mark.asyncio
+    async def test_raises_if_no_filter(self):
+        driver = SimpleDriver()
+        driver._registry = AsyncMock()
+        with pytest.raises(ValueError):
+            await driver.wait_for_device()
+
+    @pytest.mark.asyncio
+    async def test_raises_if_no_registry(self):
+        driver = SimpleDriver()
+        with pytest.raises(RuntimeError):
+            await driver.wait_for_device(device_type="robot")
+
+    @pytest.mark.asyncio
+    async def test_d2d_mode_delegates_to_collector_by_type(self):
+        driver = SimpleDriver()
+        driver._registry = AsyncMock()
+        mock_collector = AsyncMock()
+        mock_collector.wait_for_device_type = AsyncMock(
+            return_value={"device_id": "robot-01"}
+        )
+        mock_runtime = MagicMock()
+        mock_runtime._d2d_collector = mock_collector
+        driver._device = mock_runtime
+
+        result = await driver.wait_for_device(device_type="robot", timeout=5.0)
+        assert result["device_id"] == "robot-01"
+        mock_collector.wait_for_device_type.assert_called_once_with(
+            "robot", timeout=5.0
+        )
+
+    @pytest.mark.asyncio
+    async def test_d2d_mode_delegates_to_collector_by_id(self):
+        driver = SimpleDriver()
+        driver._registry = AsyncMock()
+        mock_collector = AsyncMock()
+        mock_collector.wait_for_device_id = AsyncMock(
+            return_value={"device_id": "robot-01"}
+        )
+        mock_runtime = MagicMock()
+        mock_runtime._d2d_collector = mock_collector
+        driver._device = mock_runtime
+
+        result = await driver.wait_for_device(device_id="robot-01", timeout=5.0)
+        assert result["device_id"] == "robot-01"
+        mock_collector.wait_for_device_id.assert_called_once_with(
+            "robot-01", timeout=5.0
+        )
+
+    @pytest.mark.asyncio
+    async def test_d2d_mode_raises_on_timeout(self):
+        driver = SimpleDriver()
+        driver._registry = AsyncMock()
+        mock_collector = AsyncMock()
+        mock_collector.wait_for_device_type = AsyncMock(return_value=None)
+        mock_runtime = MagicMock()
+        mock_runtime._d2d_collector = mock_collector
+        driver._device = mock_runtime
+
+        with pytest.raises(DeviceDependencyError) as exc_info:
+            await driver.wait_for_device(device_type="robot", timeout=0.5)
+        assert exc_info.value.device_type == "robot"
+        assert exc_info.value.timeout == 0.5
+
+    @pytest.mark.asyncio
+    async def test_registry_mode_polls_list_devices(self):
+        driver = SimpleDriver()
+        call_count = 0
+
+        async def mock_list(device_type=None, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                return [{"device_id": "robot-01"}]
+            return []
+
+        driver._registry = AsyncMock()
+        driver._registry.list_devices = mock_list
+        # No _d2d_collector → falls through to registry path
+        driver._device = MagicMock(spec=[])
+
+        result = await driver.wait_for_device(device_type="robot", timeout=5.0)
+        assert result["device_id"] == "robot-01"
+
+    @pytest.mark.asyncio
+    async def test_registry_mode_raises_on_timeout(self):
+        driver = SimpleDriver()
+        driver._registry = AsyncMock()
+        driver._registry.list_devices = AsyncMock(return_value=[])
+        driver._device = MagicMock(spec=[])
+
+        with pytest.raises(DeviceDependencyError):
+            await driver.wait_for_device(device_type="robot", timeout=0.3)

--- a/packages/device-connect-sdk/tests/test_zenoh_adapter.py
+++ b/packages/device-connect-sdk/tests/test_zenoh_adapter.py
@@ -190,6 +190,10 @@ class TestZenohClientConnect:
         call_args = mock_zenoh.Config.from_json5.call_args[0][0]
         config_dict = json.loads(call_args)
         assert config_dict["scouting"]["multicast"]["enabled"] is True
+        assert config_dict["scouting"]["gossip"]["enabled"] is True
+        assert config_dict["scouting"]["gossip"]["multihop"] is False
+        # Verify d2d_mode flag is set
+        assert adapter._d2d_mode is True
 
     @pytest.mark.asyncio
     @patch("device_connect_sdk.messaging.zenoh_adapter.zenoh")
@@ -576,6 +580,54 @@ class TestZenohClientSubscribe:
         mock_sub.undeclare.assert_called_once()
         mock_qable.undeclare.assert_called_once()
 
+    @pytest.mark.asyncio
+    @patch("device_connect_sdk.messaging.zenoh_adapter.zenoh")
+    @patch("device_connect_sdk.messaging.zenoh_adapter._ZENOH_AVAILABLE", True)
+    async def test_subscribe_only_skips_queryable(self, mock_zenoh):
+        session = _make_mock_session()
+        mock_zenoh.open = MagicMock(return_value=session)
+        mock_zenoh.Config.from_json5 = MagicMock(return_value=MagicMock())
+
+        from device_connect_sdk.messaging.zenoh_adapter import ZenohAdapter
+
+        adapter = ZenohAdapter()
+        await adapter.connect(servers=["tcp/host:7447"])
+
+        async def handler(data, reply):
+            pass
+
+        sub = await adapter.subscribe("test.subject", handler, subscribe_only=True)
+
+        session.declare_subscriber.assert_called_once()
+        session.declare_queryable.assert_not_called()
+
+        await sub.unsubscribe()
+
+    @pytest.mark.asyncio
+    @patch("device_connect_sdk.messaging.zenoh_adapter.zenoh")
+    @patch("device_connect_sdk.messaging.zenoh_adapter._ZENOH_AVAILABLE", True)
+    async def test_unsubscribe_with_subscribe_only(self, mock_zenoh):
+        session = _make_mock_session()
+        mock_sub = MagicMock()
+        session.declare_subscriber = MagicMock(return_value=mock_sub)
+        mock_zenoh.open = MagicMock(return_value=session)
+        mock_zenoh.Config.from_json5 = MagicMock(return_value=MagicMock())
+
+        from device_connect_sdk.messaging.zenoh_adapter import ZenohAdapter
+
+        adapter = ZenohAdapter()
+        await adapter.connect(servers=["tcp/host:7447"])
+
+        async def handler(data, reply):
+            pass
+
+        sub = await adapter.subscribe("test.subject", handler, subscribe_only=True)
+        await sub.unsubscribe()
+
+        mock_sub.undeclare.assert_called_once()
+        # queryable was never created, so no undeclare expected
+        session.declare_queryable.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # TestZenohClientSubscribeWithSubject
@@ -826,6 +878,89 @@ class TestZenohClientRequest:
         with pytest.raises(PublishError, match="query error"):
             await adapter.request("test.rpc", b"data")
 
+    @pytest.mark.asyncio
+    @patch("device_connect_sdk.messaging.zenoh_adapter.zenoh")
+    @patch("device_connect_sdk.messaging.zenoh_adapter._ZENOH_AVAILABLE", True)
+    async def test_request_d2d_retries_on_no_responders(self, mock_zenoh):
+        """D2D mode retries when session.get returns zero replies."""
+        session = _make_mock_session()
+        reply = _make_mock_reply(b"ok")
+        # First call returns no replies, second returns a reply
+        session.get = MagicMock(side_effect=[[], [reply]])
+        mock_zenoh.open = MagicMock(return_value=session)
+        mock_zenoh.Config.from_json5 = MagicMock(return_value=MagicMock())
+        mock_zenoh.CancellationToken = MagicMock(return_value=MagicMock())
+
+        from device_connect_sdk.messaging.zenoh_adapter import ZenohAdapter
+
+        adapter = ZenohAdapter()
+        await adapter.connect(servers=["zenoh://"])  # peer mode → d2d
+        adapter._d2d_retry_delay = 0.01  # speed up test
+
+        result = await adapter.request("test.rpc", b"data")
+        assert result == b"ok"
+        assert session.get.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("device_connect_sdk.messaging.zenoh_adapter.zenoh")
+    @patch("device_connect_sdk.messaging.zenoh_adapter._ZENOH_AVAILABLE", True)
+    async def test_request_d2d_uses_query_target_all(self, mock_zenoh):
+        """D2D mode passes QueryTarget.ALL to session.get()."""
+        session = _make_mock_session()
+        reply = _make_mock_reply(b"ok")
+        session.get = MagicMock(return_value=[reply])
+        mock_zenoh.open = MagicMock(return_value=session)
+        mock_zenoh.Config.from_json5 = MagicMock(return_value=MagicMock())
+        mock_zenoh.CancellationToken = MagicMock(return_value=MagicMock())
+        mock_zenoh.QueryTarget.ALL = "ALL"
+        mock_zenoh.ConsolidationMode.NONE = "NONE"
+
+        from device_connect_sdk.messaging.zenoh_adapter import ZenohAdapter
+
+        adapter = ZenohAdapter()
+        await adapter.connect(servers=["zenoh://"])
+
+        await adapter.request("test.rpc", b"data")
+
+        call_kwargs = session.get.call_args[1]
+        assert call_kwargs["target"] == "ALL"
+        assert call_kwargs["consolidation"] == "NONE"
+
+    @pytest.mark.asyncio
+    @patch("device_connect_sdk.messaging.zenoh_adapter.zenoh")
+    @patch("device_connect_sdk.messaging.zenoh_adapter._ZENOH_AVAILABLE", True)
+    async def test_request_router_mode_no_retry(self, mock_zenoh):
+        """Router mode does NOT retry on no responders."""
+        session = _make_mock_session()
+        session.get = MagicMock(return_value=[])
+        mock_zenoh.open = MagicMock(return_value=session)
+        mock_zenoh.Config.from_json5 = MagicMock(return_value=MagicMock())
+        mock_zenoh.CancellationToken = MagicMock(return_value=MagicMock())
+
+        from device_connect_sdk.messaging.zenoh_adapter import ZenohAdapter
+        from device_connect_sdk.messaging.exceptions import RequestTimeoutError
+
+        adapter = ZenohAdapter()
+        await adapter.connect(servers=["tcp/host:7447"])  # router mode
+
+        with pytest.raises(RequestTimeoutError):
+            await adapter.request("test.rpc", b"data", timeout=0.1)
+        # Only 1 attempt in router mode
+        assert session.get.call_count == 1
+
+    @pytest.mark.asyncio
+    @patch("device_connect_sdk.messaging.zenoh_adapter.zenoh")
+    @patch("device_connect_sdk.messaging.zenoh_adapter._ZENOH_AVAILABLE", True)
+    async def test_configure_d2d_retry(self, mock_zenoh):
+        """configure_d2d_retry updates retry parameters."""
+        from device_connect_sdk.messaging.zenoh_adapter import ZenohAdapter
+
+        adapter = ZenohAdapter()
+        adapter.configure_d2d_retry(retries=5, delay=1.0)
+
+        assert adapter._d2d_retry_count == 5
+        assert adapter._d2d_retry_delay == 1.0
+
 
 # ---------------------------------------------------------------------------
 # TestZenohClientClose
@@ -906,6 +1041,37 @@ class TestZenohClientClose:
 
         await adapter.close()
         assert len(adapter._pending_queries) == 0
+
+    @pytest.mark.asyncio
+    @patch("device_connect_sdk.messaging.zenoh_adapter.zenoh")
+    @patch("device_connect_sdk.messaging.zenoh_adapter._ZENOH_AVAILABLE", True)
+    async def test_close_undeclares_queryables_before_subscribers(self, mock_zenoh):
+        """Phased teardown: queryable.undeclare() must happen before subscriber.undeclare()."""
+        session = _make_mock_session()
+        mock_sub = MagicMock()
+        mock_qable = MagicMock()
+        session.declare_subscriber = MagicMock(return_value=mock_sub)
+        session.declare_queryable = MagicMock(return_value=mock_qable)
+        mock_zenoh.open = MagicMock(return_value=session)
+        mock_zenoh.Config.from_json5 = MagicMock(return_value=MagicMock())
+
+        from device_connect_sdk.messaging.zenoh_adapter import ZenohAdapter
+
+        adapter = ZenohAdapter()
+        await adapter.connect(servers=["tcp/host:7447"])
+
+        async def handler(data, reply):
+            pass
+
+        await adapter.subscribe("test.subject", handler)
+
+        call_order = []
+        mock_qable.undeclare = MagicMock(side_effect=lambda: call_order.append("queryable"))
+        mock_sub.undeclare = MagicMock(side_effect=lambda: call_order.append("subscriber"))
+
+        await adapter.close()
+
+        assert call_order == ["queryable", "subscriber"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Zenoh D2D reliability**: SDK-level retry on `request()` with configurable attempts/delay, `QueryTarget.ALL` in peer mode, gossip scouting with multihop enabled
- **`subscribe_only` flag**: Skips Zenoh queryable declaration for pure pub/sub consumers (presence collectors, event subscriptions), reducing resource overhead
- **Graceful shutdown**: Departure announcements so peers prune immediately; phased teardown (queryables → subscribers → session) with propagation delay in D2D mesh
- **`wait_for_device()` API + `depends_on`**: New `DeviceDriver.wait_for_device(device_type=..., device_id=..., timeout=...)` method with polling in both D2D and registry modes. Class-level `depends_on` tuple gates startup until required peer device types are present
- **Bug fixes**: Missing module-level logger in `device.py`, collector lifecycle dedup (no duplicate `PresenceCollector` in D2D), `RuntimeError` guards in Zenoh thread callbacks during shutdown
- **Cleanup**: Export `DeviceDependencyError` from package `__init__`, immutable `depends_on` default (tuple instead of list), `_started` guards on `PresenceCollector.wait_for_device_type/id`

## Test plan

- [x] All 347 SDK unit tests pass (`pytest tests/ -v`)
- [x] Integration tests with Docker infrastructure (`docker-compose-itest.yml`)