### PR TITLE
Fix split-package SDK imports and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,10 @@ jobs:
         run: pip install ruff
       - name: Lint all packages
         run: |
-          ruff check packages/device-connect-sdk/device_connect_sdk/
-          ruff check packages/device-connect-server/device_connect_server/
-          ruff check packages/device-connect-agent-tools/device_connect_agent_tools/
+          ruff check packages/device-connect-sdk/
+          ruff check packages/device-connect-server/
+          ruff check packages/device-connect-agent-tools/
+          ruff check tests/
 
   # ── Tier 1: Integration tests (no LLM) ────────────────────────
   integration-tests:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 .eggs/
 *.egg
 .venv/
+.vscode/
 .env
 .pytest_cache/
 .mypy_cache/

--- a/packages/device-connect-agent-tools/tests/test_connection_unit.py
+++ b/packages/device-connect-agent-tools/tests/test_connection_unit.py
@@ -6,7 +6,6 @@ using mocks (no real NATS required).
 
 import json
 import os
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/packages/device-connect-agent-tools/tests/test_integration.py
+++ b/packages/device-connect-agent-tools/tests/test_integration.py
@@ -206,7 +206,7 @@ class TestStandaloneToolsLLM:
     def test_strands_agent_with_device_connect_tools(self, device_connect_connection, api_key):
         """A plain Strands Agent should be able to use Device Connect tools."""
         from strands import Agent
-        from device_connect_agent_tools import discover_devices, invoke_device
+        from device_connect_agent_tools import discover_devices
 
         api_key_value, provider = api_key
 

--- a/packages/device-connect-agent-tools/tests/test_strands_adapter.py
+++ b/packages/device-connect-agent-tools/tests/test_strands_adapter.py
@@ -30,7 +30,7 @@ def _install_strands_mock():
 @pytest.fixture(autouse=True)
 def _mock_strands_and_connection():
     """Mock the strands package and the Device Connect connection for all tests."""
-    strands_mod = _install_strands_mock()
+    _install_strands_mock()
 
     mock_conn = MagicMock()
     mock_conn.list_devices.return_value = []

--- a/packages/device-connect-sdk/device_connect_sdk/device.py
+++ b/packages/device-connect-sdk/device_connect_sdk/device.py
@@ -32,7 +32,7 @@ Authentication Modes:
        - Not suitable for production deployments
 
 Example:
-    from fabric import DeviceRuntime
+    from device_connect_sdk import DeviceRuntime
     from device_connect_sdk.drivers import DeviceDriver, rpc
 
     class CameraDriver(DeviceDriver):
@@ -181,7 +181,7 @@ class DeviceRuntime:
         commissioning_port: TCP port for commissioning server (default: 5540)
 
     Example (Driver-based):
-        from fabric import DeviceRuntime
+        from device_connect_sdk import DeviceRuntime
         from device_connect_sdk.drivers import DeviceDriver, rpc
 
         class CameraDriver(DeviceDriver):
@@ -198,7 +198,7 @@ class DeviceRuntime:
         )
 
     Example (Type models):
-        from fabric import DeviceRuntime
+        from device_connect_sdk import DeviceRuntime
         from device_connect_sdk.types import DeviceCapabilities, DeviceIdentity, DeviceStatus
 
         device = DeviceRuntime(
@@ -582,7 +582,7 @@ class DeviceRuntime:
                 f"  1. Set the credentials file path correctly\n"
                 f"  2. Verified the file exists and is readable\n\n"
                 f"For NATS JWT auth, commission the device first:\n"
-                f"  python -m fabric.devctl commission <device-id> --pin <pin>\n"
+                f"  python -m device_connect_server.devctl commission <device-id> --pin <pin>\n"
                 f"For Zenoh mTLS, generate a client cert:\n"
                 f"  ./security_infra/generate_tls_certs.sh --client <device-id>\n"
                 f"{'='*70}\n"
@@ -818,15 +818,12 @@ class DeviceRuntime:
             Path to credentials file
         """
         try:
-            from device_connect_sdk.security.commissioning import CommissioningMode
+            from device_connect_server.security.commissioning import CommissioningMode
         except ImportError:
-            try:
-                from fabric.security.commissioning import CommissioningMode
-            except ImportError:
-                raise ImportError(
-                    "Commissioning requires device-connect-server[security]. "
-                    "Install with: pip install 'device-connect-server[security]'"
-                )
+            raise ImportError(
+                "Commissioning requires device-connect-server[security]. "
+                "Install with: pip install 'device-connect-server[security]'"
+            )
 
         if not self._factory_identity:
             raise ValueError("Factory identity required for commissioning")
@@ -1503,10 +1500,7 @@ class DeviceRuntime:
             self._logger.debug("D2DRegistry configured for DeviceDriver (no infrastructure)")
         else:
             try:
-                try:
-                    from device_connect_sdk.registry.client import RegistryClient
-                except ImportError:
-                    from fabric.registry.client import RegistryClient
+                from device_connect_server.registry.client import RegistryClient
                 from device_connect_sdk.messaging.config import MessagingConfig
                 config = MessagingConfig(
                     backend=self._messaging_backend or "zenoh",
@@ -1576,5 +1570,3 @@ class DeviceRuntime:
                 asyncio.create_task(cb())
             except Exception as e:
                 self._logger.exception("Registration callback error: %s", e)
-
-

--- a/packages/device-connect-sdk/device_connect_sdk/drivers/base.py
+++ b/packages/device-connect-sdk/device_connect_sdk/drivers/base.py
@@ -82,12 +82,9 @@ from device_connect_sdk.telemetry.propagation import inject_into_meta
 if TYPE_CHECKING:
     from device_connect_sdk.device import DeviceRuntime, _D2DRouter as DeviceRouter
     try:
-        from device_connect_sdk.registry.client import RegistryClient
+        from device_connect_server.registry.client import RegistryClient
     except ImportError:
-        try:
-            from fabric.registry.client import RegistryClient  # type: ignore[assignment]
-        except ImportError:
-            pass
+        pass
 
 
 logger = logging.getLogger("device_connect.drivers.base")

--- a/packages/device-connect-sdk/examples/string_generator/device_simulator.py
+++ b/packages/device-connect-sdk/examples/string_generator/device_simulator.py
@@ -211,7 +211,7 @@ async def run(device_id: str, interval: float, creds_file: Optional[str] = None)
     """Start the device simulator."""
     nats_url = os.getenv("NATS_URL", "nats://localhost:4222")
     tenant = os.getenv("TENANT", "default")
-    allow_insecure = os.getenv("DEVICE_CONNECT_ALLOW_INSECURE", "").lower() in ("1", "true", "yes")
+
 
     driver = StringGeneratorDriver(interval=interval)
 

--- a/packages/device-connect-sdk/tests/test_device.py
+++ b/packages/device-connect-sdk/tests/test_device.py
@@ -9,7 +9,7 @@ import json
 import os
 import sys
 import types
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 

--- a/packages/device-connect-sdk/tests/test_device.py
+++ b/packages/device-connect-sdk/tests/test_device.py
@@ -7,6 +7,8 @@ and _D2DRouter — all with mocked messaging (no real NATS connection).
 import asyncio
 import json
 import os
+import sys
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -357,3 +359,134 @@ class TestEnqueueEvent:
         await rt.enqueue_event("eventA", {"a": 1})
         await rt.enqueue_event("eventB", {"b": 2})
         assert rt._event_queue.qsize() == 2
+
+
+def _fake_package(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    module.__path__ = []  # type: ignore[attr-defined]
+    return module
+
+
+# ── Split-package compatibility regressions ──────────────────────
+
+class TestSplitPackageImports:
+    def test_missing_credentials_error_references_devctl_module(self):
+        rt = DeviceRuntime(device_id="sensor-1", messaging_urls=["nats://localhost:4222"])
+
+        with pytest.raises(FileNotFoundError) as excinfo:
+            rt._load_credentials("/definitely/missing.creds.json")
+
+        assert "python -m device_connect_server.devctl commission" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_run_commissioning_imports_from_device_connect_server(self, tmp_path):
+        calls = {}
+
+        class FakeCommissioningMode:
+            def __init__(
+                self,
+                *,
+                device_id,
+                device_type,
+                factory_pin,
+                capabilities,
+                nkey_public,
+                nkey_seed,
+                port,
+            ):
+                calls["init"] = {
+                    "device_id": device_id,
+                    "device_type": device_type,
+                    "factory_pin": factory_pin,
+                    "capabilities": capabilities,
+                    "nkey_public": nkey_public,
+                    "nkey_seed": nkey_seed,
+                    "port": port,
+                }
+
+            async def start_commissioning_server(self):
+                calls["started"] = True
+                return {"device_id": "sensor-1", "nats": {"jwt": "jwt", "nkey_seed": "seed"}}
+
+            def save_credentials(self, credentials, path):
+                calls["saved"] = {"credentials": credentials, "path": path}
+
+        server_pkg = _fake_package("device_connect_server")
+        security_pkg = _fake_package("device_connect_server.security")
+        commissioning_mod = types.ModuleType("device_connect_server.security.commissioning")
+        commissioning_mod.CommissioningMode = FakeCommissioningMode
+
+        identity_payload = {
+            "device_id": "sensor-1",
+            "device_type": "sensor",
+            "capabilities": {"functions": [], "events": []},
+            "provisioning": {"pin": "1234-5678", "commissioned": False},
+            "nkey": {"public_key": "PUB", "seed": "SEED"},
+        }
+        identity_path = tmp_path / "factory_identity.json"
+        identity_path.write_text(json.dumps(identity_payload))
+
+        rt = DeviceRuntime(
+            device_id="sensor-1",
+            messaging_urls=["nats://localhost:4222"],
+            factory_identity_file=str(identity_path),
+            auto_commission=False,
+        )
+        rt._factory_identity = dict(identity_payload)
+
+        with patch.dict(
+            sys.modules,
+            {
+                "device_connect_server": server_pkg,
+                "device_connect_server.security": security_pkg,
+                "device_connect_server.security.commissioning": commissioning_mod,
+            },
+            clear=False,
+        ):
+            creds_path = await rt._run_commissioning()
+
+        assert calls["init"]["device_id"] == "sensor-1"
+        assert calls["init"]["device_type"] == "sensor"
+        assert calls["init"]["port"] == rt.commissioning_port
+        assert calls["started"] is True
+        assert calls["saved"]["path"] == creds_path
+        assert rt._factory_identity["provisioning"]["commissioned"] is True
+
+    @pytest.mark.asyncio
+    async def test_setup_agentic_driver_imports_registry_from_device_connect_server(self):
+        class FakeRegistryClient:
+            def __init__(self, messaging, config, tenant="default"):
+                self.messaging = messaging
+                self.config = config
+                self.tenant = tenant
+
+        server_pkg = _fake_package("device_connect_server")
+        registry_pkg = _fake_package("device_connect_server.registry")
+        registry_mod = types.ModuleType("device_connect_server.registry.client")
+        registry_mod.RegistryClient = FakeRegistryClient
+
+        driver = StubDriver()
+        rt = DeviceRuntime(
+            driver=driver,
+            device_id="sensor-1",
+            messaging_urls=["nats://localhost:4222"],
+        )
+        rt._d2d_mode = False
+        rt.messaging = AsyncMock()
+
+        with patch.dict(
+            sys.modules,
+            {
+                "device_connect_server": server_pkg,
+                "device_connect_server.registry": registry_pkg,
+                "device_connect_server.registry.client": registry_mod,
+            },
+            clear=False,
+        ):
+            await rt._setup_agentic_driver()
+
+        assert isinstance(driver.registry, FakeRegistryClient)
+        assert driver.registry.messaging is rt.messaging
+        assert driver.registry.tenant == "default"
+        assert driver.registry.config.backend == "nats"
+        assert driver.registry.config.servers == ["nats://localhost:4222"]

--- a/packages/device-connect-sdk/tests/test_discovery.py
+++ b/packages/device-connect-sdk/tests/test_discovery.py
@@ -7,14 +7,12 @@ with mocked messaging (no real Zenoh/NATS connection).
 import asyncio
 import json
 import time
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
 from device_connect_sdk.discovery import (
     BURST_INTERVAL,
-    STEADY_INTERVAL,
-    BURST_DURATION,
     PEER_TIMEOUT,
     PresenceAnnouncer,
     PresenceCollector,

--- a/packages/device-connect-sdk/tests/test_driver_transport.py
+++ b/packages/device-connect-sdk/tests/test_driver_transport.py
@@ -1,7 +1,6 @@
 """Tests for DriverTransport — raw messaging transport for DeviceDriver."""
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/packages/device-connect-sdk/tests/test_drivers.py
+++ b/packages/device-connect-sdk/tests/test_drivers.py
@@ -3,8 +3,6 @@
 Tests @rpc, @emit decorators, schema generation, and DeviceDriver base class.
 """
 
-import asyncio
-from unittest.mock import AsyncMock
 
 import pytest
 

--- a/packages/device-connect-sdk/tests/test_file_buffer_exporter.py
+++ b/packages/device-connect-sdk/tests/test_file_buffer_exporter.py
@@ -1,10 +1,8 @@
 """Tests for device_connect_sdk.telemetry.file_buffer_exporter module."""
 
 import json
-import time
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from device_connect_sdk.telemetry.file_buffer_exporter import (
     FileBufferSpanExporter,

--- a/packages/device-connect-sdk/tests/test_mqtt_adapter.py
+++ b/packages/device-connect-sdk/tests/test_mqtt_adapter.py
@@ -3,8 +3,7 @@
 The ``aiomqtt`` library is fully mocked so no real MQTT broker is needed.
 """
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 

--- a/packages/device-connect-sdk/tests/test_telemetry.py
+++ b/packages/device-connect-sdk/tests/test_telemetry.py
@@ -8,10 +8,8 @@ Tests cover:
 - DeviceConnectTelemetry initialization and provider reuse
 """
 
-import uuid
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-import pytest
 
 
 # -- No-op behavior tests --
@@ -135,7 +133,7 @@ class TestPropagation:
         from device_connect_sdk.telemetry.propagation import extract_from_meta
 
         meta = {"source_device": "test-001"}
-        ctx = extract_from_meta(meta)
+        extract_from_meta(meta)
         # Should return None or a Context -- never raise
 
     def test_inject_into_payload_adds_fields(self):
@@ -152,7 +150,7 @@ class TestPropagation:
         from device_connect_sdk.telemetry.propagation import extract_from_payload
 
         payload = {"plate_id": "P003", "_traceparent": "00-abc-def-01"}
-        ctx = extract_from_payload(payload)
+        extract_from_payload(payload)
         # Should not raise
 
     def test_inject_extract_meta_roundtrip(self):
@@ -161,7 +159,7 @@ class TestPropagation:
 
         meta = {"source_device": "cam-001"}
         inject_into_meta(meta)
-        ctx = extract_from_meta(meta)
+        extract_from_meta(meta)
         # If OTel is installed, ctx should be a Context; if not, None
         # Either way, this should not raise
 
@@ -227,7 +225,7 @@ class TestDeviceConnectTelemetryConfig:
             cfg._initialized = False
             with patch.dict("os.environ", {"OTEL_SDK_DISABLED": "true"}):
                 from device_connect_sdk.telemetry.config import DeviceConnectTelemetry
-                t = DeviceConnectTelemetry(service_name="test-disabled")
+                DeviceConnectTelemetry(service_name="test-disabled")
                 # After init with OTEL_SDK_DISABLED, should stay disabled
                 # (actual behavior depends on whether OTel is installed)
         finally:

--- a/packages/device-connect-sdk/tests/test_types.py
+++ b/packages/device-connect-sdk/tests/test_types.py
@@ -4,7 +4,6 @@ from device_connect_sdk.types import (
     DeviceState,
     DeviceIdentity,
     DeviceStatus,
-    DeviceCapabilities,
     FunctionDef,
     EventDef,
 )

--- a/packages/device-connect-sdk/tests/test_wait_for_device.py
+++ b/packages/device-connect-sdk/tests/test_wait_for_device.py
@@ -1,6 +1,5 @@
 """Tests for DeviceDriver.wait_for_device() and depends_on startup gating."""
 
-import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 

--- a/packages/device-connect-sdk/tests/test_zenoh_adapter.py
+++ b/packages/device-connect-sdk/tests/test_zenoh_adapter.py
@@ -6,8 +6,7 @@ The Zenoh Python SDK is synchronous, so mocks use MagicMock (not AsyncMock).
 
 import asyncio
 import json
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -526,7 +525,6 @@ class TestZenohClientSubscribe:
         mock_zenoh.Config.from_json5 = MagicMock(return_value=MagicMock())
 
         from device_connect_sdk.messaging.zenoh_adapter import ZenohAdapter
-        import logging
 
         adapter = ZenohAdapter()
         await adapter.connect(servers=["tcp/host:7447"])

--- a/packages/device-connect-server/pyproject.toml
+++ b/packages/device-connect-server/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-timeout>=2.0",
+    "device-connect-server[security]",
 ]
 all = [
     "device-connect-server[security,telemetry,state,logging,mqtt,dev]",

--- a/packages/device-connect-server/tests/device_connect_server/test_agentic_driver.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_agentic_driver.py
@@ -1,8 +1,6 @@
 """Tests for D2D (device-to-device) communication in DeviceDriver."""
-import asyncio
-import json
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from device_connect_server.drivers.base import DeviceDriver, on
 from device_connect_server.drivers.decorators import rpc

--- a/packages/device-connect-server/tests/device_connect_server/test_capability_loader.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_capability_loader.py
@@ -8,17 +8,14 @@ Tests cover:
 - Unloading capabilities
 """
 
-import asyncio
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
 from device_connect_server.drivers.capability_loader import (
     CapabilityLoader,
-    LoadedCapability,
-    EventSubscription,
 )
 
 

--- a/packages/device-connect-server/tests/device_connect_server/test_devctl_cli.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_devctl_cli.py
@@ -1,7 +1,6 @@
 """Tests for device_connect_server.devctl.cli module."""
 
 import json
-from io import StringIO
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/packages/device-connect-server/tests/device_connect_server/test_drivers.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_drivers.py
@@ -8,7 +8,6 @@ from device_connect_server.drivers import (
     build_function_schema,
     build_event_schema,
 )
-from device_connect_server.types import DeviceCapabilities, DeviceIdentity
 
 
 class TestRpc:

--- a/packages/device-connect-server/tests/device_connect_server/test_etcd_state_store.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_etcd_state_store.py
@@ -4,10 +4,9 @@ Tests can run as integration tests against a real etcd instance
 (requires Docker) or as unit tests with mocked etcd3gw client.
 """
 
-import asyncio
 import base64
 import json
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/packages/device-connect-server/tests/device_connect_server/test_logging.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_logging.py
@@ -1,6 +1,5 @@
 """Tests for device_connect_server.logging module."""
 import pytest
-import time
 from device_connect_server.logging import (
     AuditLogger,
     LogEntry,

--- a/packages/device-connect-server/tests/device_connect_server/test_registry_client.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_registry_client.py
@@ -4,7 +4,7 @@ Tests use a mocked MessagingClient — no real NATS required.
 """
 
 import json
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import pytest
 
@@ -75,7 +75,7 @@ class TestRegistryClientConnection:
     @pytest.mark.asyncio
     async def test_context_manager(self):
         mc = _mock_messaging({"result": {}})
-        async with RegistryClient(mc) as client:
+        async with RegistryClient(mc) as _client:
             pass
         mc.close.assert_called_once()
 

--- a/packages/device-connect-server/tests/device_connect_server/test_registry_service.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_registry_service.py
@@ -11,7 +11,6 @@ import json
 import sys
 from unittest.mock import MagicMock, patch, call
 
-import pytest
 
 # ---------------------------------------------------------------------------
 # Inject mock etcd3gw into sys.modules BEFORE importing the registry module.

--- a/packages/device-connect-server/tests/device_connect_server/test_security_acl.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_security_acl.py
@@ -1,6 +1,5 @@
 """Tests for device_connect_server.security.acl module."""
 
-import pytest
 from device_connect_server.security.acl import (
     EventACL,
     FunctionACL,

--- a/packages/device-connect-server/tests/device_connect_server/test_statectl_cli.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_statectl_cli.py
@@ -1,8 +1,6 @@
 """Tests for device_connect_server.statectl.cli helper functions."""
 
 import base64
-import json
-from unittest.mock import MagicMock
 
 from device_connect_server.statectl.cli import (
     _kv_key,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ ITEST_ROOT = Path(__file__).parent
 if str(ITEST_ROOT) not in sys.path:
     sys.path.insert(0, str(ITEST_ROOT))
 
-from fixtures.infrastructure import (
+from fixtures.infrastructure import (  # noqa: E402
     DockerComposeManager,
     clear_device_registry,
     wait_for_all_services,

--- a/tests/fixtures/inject.py
+++ b/tests/fixtures/inject.py
@@ -3,7 +3,6 @@
 Uses the SDK MessagingClient abstraction — supports NATS, Zenoh, and MQTT backends.
 """
 
-import asyncio
 import json
 import logging
 import uuid

--- a/tests/tests/test_d2d_discovery.py
+++ b/tests/tests/test_d2d_discovery.py
@@ -11,8 +11,6 @@ Requires: eclipse-zenoh Python package installed.
 
 import asyncio
 import json
-import os
-import time
 
 import pytest
 
@@ -37,8 +35,8 @@ def d2d_env(monkeypatch):
     monkeypatch.delenv("NATS_URLS", raising=False)
 
 
-from device_connect_sdk.drivers import DeviceDriver, rpc
-from device_connect_sdk.types import DeviceIdentity, DeviceStatus
+from device_connect_sdk.drivers import DeviceDriver, rpc  # noqa: E402
+from device_connect_sdk.types import DeviceIdentity, DeviceStatus  # noqa: E402
 
 
 class _StubDriver(DeviceDriver):

--- a/tests/tests/test_d2d_events.py
+++ b/tests/tests/test_d2d_events.py
@@ -6,8 +6,6 @@ and reacts automatically via NATS pub/sub.
 
 import asyncio
 import time
-import uuid
-from typing import Optional
 
 import pytest
 

--- a/tests/tests/test_messaging_conformance.py
+++ b/tests/tests/test_messaging_conformance.py
@@ -143,7 +143,6 @@ class TestMessagingConformance:
     async def test_wildcard_subscribe(self, messaging_client):
         """Wildcard subscribe (*.event.*) should match multiple subjects."""
         received = []
-        pattern = f"conformance.*.event.{uuid.uuid4().hex[:6]}"
         unique = uuid.uuid4().hex[:6]
 
         async def handler(data, reply):


### PR DESCRIPTION
## Summary
- fix stale SDK docstring examples and commissioning guidance so they reference the split packages that actually exist
- update runtime imports to load `CommissioningMode` and `RegistryClient` from `device_connect_server` instead of removed legacy paths
- add regression coverage for commissioning imports, non-D2D registry wiring, and the user-facing commissioning hint
- ignore `.vscode/` so local editor settings do not leak into commits

## Testing
- `.venv/bin/python -m pytest packages/device-connect-sdk/tests/test_device.py -q`
- `.venv/bin/python -m pytest packages/device-connect-sdk/tests -q`