### PR TITLE
feat: add Claude Agent SDK adapter

### DIFF
--- a/packages/device-connect-agent-tools/README.md
+++ b/packages/device-connect-agent-tools/README.md
@@ -1,6 +1,6 @@
 # device-connect-agent-tools
 
-Framework-agnostic tools for Device Connect — discover and invoke devices from any AI agent. Plain Python functions at the core, with adapters for [Strands](#strands-agent), [LangChain](#langchain--langgraph), and [MCP](#mcp-bridge).
+Framework-agnostic tools for Device Connect — discover and invoke devices from any AI agent. Plain Python functions at the core, with adapters for [Strands](#strands-agent), [LangChain](#langchain--langgraph), [Claude Agent SDK](#claude-agent-sdk), and [MCP](#mcp-bridge).
 
 ## Contents
 
@@ -15,6 +15,7 @@ Framework-agnostic tools for Device Connect — discover and invoke devices from
     - [Plain Python (no framework)](#plain-python-no-framework)
     - [Strands Agent](#strands-agent)
     - [LangChain / LangGraph](#langchain--langgraph)
+    - [Claude Agent SDK](#claude-agent-sdk)
     - [MCP Bridge](#mcp-bridge)
   - [Connection](#connection)
     - [Auto-Discovery](#auto-discovery)
@@ -61,6 +62,7 @@ Optional extras:
 |-------|------|
 | `[strands]` | [Strands Agents](https://strandsagents.com) adapter |
 | `[langchain]` | [LangChain](https://python.langchain.com) adapter |
+| `[claude]` | [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) adapter |
 | `[mcp]` | [FastMCP](https://github.com/jlowin/fastmcp) for MCP bridge |
 | `[dev]` | pytest + dev tools |
 
@@ -236,6 +238,31 @@ agent = create_react_agent(model, tools=[describe_fleet, list_devices, get_devic
 
 result = agent.invoke({"messages": [{"role": "user", "content": "What devices are online?"}]})
 print(result["messages"][-1].content)
+```
+
+### Claude Agent SDK
+
+```python
+import anyio
+from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions, AssistantMessage, TextBlock
+from device_connect_agent_tools import connect
+from device_connect_agent_tools.adapters.claude import create_device_connect_server
+
+async def main():
+    connect()
+    options = ClaudeAgentOptions(
+        model="claude-sonnet-4-6",
+        mcp_servers={"device_connect": create_device_connect_server()},
+    )
+    async with ClaudeSDKClient(options=options) as client:
+        await client.query("What devices are online?")
+        async for message in client.receive_response():
+            if isinstance(message, AssistantMessage):
+                for block in message.content:
+                    if isinstance(block, TextBlock):
+                        print(block.text)
+
+anyio.run(main)
 ```
 
 ### MCP Bridge

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/__init__.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/__init__.py
@@ -3,8 +3,15 @@
 Import tools from the adapter matching your agent framework:
 
     # Strands
-    from device_connect_agent_tools.adapters.strands import discover_devices, invoke_device
+    from device_connect_agent_tools.adapters.strands import (
+        describe_fleet, list_devices, get_device_functions, invoke_device,
+    )
 
     # LangChain
-    from device_connect_agent_tools.adapters.langchain import discover_devices, invoke_device
+    from device_connect_agent_tools.adapters.langchain import (
+        describe_fleet, list_devices, get_device_functions, invoke_device,
+    )
+
+    # Claude Agent SDK
+    from device_connect_agent_tools.adapters.claude import create_device_connect_server
 """

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/claude.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/claude.py
@@ -1,0 +1,198 @@
+"""Claude Agent SDK adapter — exposes Device Connect tools to claude-agent-sdk.
+
+Hierarchical discovery keeps LLM context small::
+
+    import anyio
+    from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions, AssistantMessage, TextBlock
+    from device_connect_agent_tools import connect
+    from device_connect_agent_tools.adapters.claude import create_device_connect_server
+
+    async def main():
+        connect()
+        options = ClaudeAgentOptions(
+            model="claude-sonnet-4-6",
+            mcp_servers={"device_connect": create_device_connect_server()},
+        )
+        async with ClaudeSDKClient(options=options) as client:
+            await client.query("What devices are online?")
+            async for message in client.receive_response():
+                if isinstance(message, AssistantMessage):
+                    for block in message.content:
+                        if isinstance(block, TextBlock):
+                            print(block.text)
+
+    anyio.run(main)
+
+Unlike the Strands and LangChain adapters, ``claude_agent_sdk.tool`` does not
+introspect the wrapped function — name, description, and schema are passed
+explicitly per tool, which is why this module is longer than its siblings.
+
+Requires: pip install device-connect-agent-tools[claude]
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from claude_agent_sdk import tool, create_sdk_mcp_server
+
+from device_connect_agent_tools.tools import (
+    describe_fleet as _describe_fleet,
+    list_devices as _list_devices,
+    get_device_functions as _get_device_functions,
+    discover_devices as _discover_devices,
+    invoke_device as _invoke_device,
+    invoke_device_with_fallback as _invoke_device_with_fallback,
+    get_device_status as _get_device_status,
+)
+
+
+def _text(result: Any) -> dict[str, Any]:
+    return {"content": [{"type": "text", "text": json.dumps(result, default=str)}]}
+
+
+# Hierarchical discovery tools (recommended)
+
+
+@tool(
+    "describe_fleet",
+    "Get a high-level summary of all available devices, grouped by type and "
+    "location. Use this first to understand what is available, then call "
+    "list_devices to browse specific types or locations.",
+    {},
+)
+async def describe_fleet(args: dict[str, Any]) -> dict[str, Any]:
+    return _text(_describe_fleet())
+
+
+@tool(
+    "list_devices",
+    "Browse available devices with filtering and pagination. Returns compact "
+    "device summaries (no full schemas). Use get_device_functions for details.",
+    {
+        "device_type": str,
+        "location": str,
+        "status": str,
+        "group_by": str,
+        "offset": int,
+        "limit": int,
+    },
+)
+async def list_devices(args: dict[str, Any]) -> dict[str, Any]:
+    return _text(
+        _list_devices(
+            device_type=args.get("device_type"),
+            location=args.get("location"),
+            status=args.get("status"),
+            group_by=args.get("group_by"),
+            offset=int(args.get("offset", 0)),
+            limit=int(args.get("limit", 20)),
+        )
+    )
+
+
+@tool(
+    "get_device_functions",
+    "Get full function schemas for a specific device. Call this after "
+    "list_devices to see what a device can do and what parameters each "
+    "function accepts.",
+    {"device_id": str},
+)
+async def get_device_functions(args: dict[str, Any]) -> dict[str, Any]:
+    return _text(_get_device_functions(device_id=args["device_id"]))
+
+
+# Invocation tools
+
+
+@tool(
+    "invoke_device",
+    "Call a function on a Device Connect device. Use get_device_functions "
+    "first to learn available functions and parameters.",
+    {"device_id": str, "function": str, "params": dict, "llm_reasoning": str},
+)
+async def invoke_device(args: dict[str, Any]) -> dict[str, Any]:
+    return _text(
+        _invoke_device(
+            device_id=args["device_id"],
+            function=args["function"],
+            params=args.get("params"),
+            llm_reasoning=args.get("llm_reasoning"),
+        )
+    )
+
+
+@tool(
+    "invoke_device_with_fallback",
+    "Call a function with automatic fallback across a list of device IDs. "
+    "Tries each device in order until one succeeds.",
+    {"device_ids": list, "function": str, "params": dict, "llm_reasoning": str},
+)
+async def invoke_device_with_fallback(args: dict[str, Any]) -> dict[str, Any]:
+    return _text(
+        _invoke_device_with_fallback(
+            device_ids=args["device_ids"],
+            function=args["function"],
+            params=args.get("params"),
+            llm_reasoning=args.get("llm_reasoning"),
+        )
+    )
+
+
+@tool(
+    "get_device_status",
+    "Get detailed status of a specific Device Connect device.",
+    {"device_id": str},
+)
+async def get_device_status(args: dict[str, Any]) -> dict[str, Any]:
+    return _text(_get_device_status(device_id=args["device_id"]))
+
+
+# Backward-compatible (deprecated — use hierarchical tools instead)
+
+
+@tool(
+    "discover_devices",
+    "Deprecated — use describe_fleet, list_devices, and get_device_functions "
+    "instead. Discover all devices with full function schemas.",
+    {"device_type": str, "refresh": bool},
+)
+async def discover_devices(args: dict[str, Any]) -> dict[str, Any]:
+    return _text(
+        _discover_devices(
+            device_type=args.get("device_type"),
+            refresh=bool(args.get("refresh", False)),
+        )
+    )
+
+
+def create_device_connect_server(name: str = "device-connect"):
+    """Return an in-process SDK MCP server exposing all Device Connect tools.
+
+    Pass the result in ``ClaudeAgentOptions(mcp_servers={...})``.
+    """
+    return create_sdk_mcp_server(
+        name,
+        tools=[
+            describe_fleet,
+            list_devices,
+            get_device_functions,
+            invoke_device,
+            invoke_device_with_fallback,
+            get_device_status,
+            discover_devices,
+        ],
+    )
+
+
+__all__ = [
+    "describe_fleet",
+    "list_devices",
+    "get_device_functions",
+    "discover_devices",
+    "invoke_device",
+    "invoke_device_with_fallback",
+    "get_device_status",
+    "create_device_connect_server",
+]

--- a/packages/device-connect-agent-tools/pyproject.toml
+++ b/packages/device-connect-agent-tools/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 [project.optional-dependencies]
 strands = ["strands-agents>=1.0"]
 langchain = ["langchain-core>=0.2"]
+claude = ["claude-agent-sdk>=0.1"]
 mcp = ["fastmcp>=1.0"]
 dev = [
     "pytest>=8.0",

--- a/packages/device-connect-agent-tools/tests/test_claude_adapter.py
+++ b/packages/device-connect-agent-tools/tests/test_claude_adapter.py
@@ -1,0 +1,106 @@
+"""Unit tests for device_connect_agent_tools.adapters.claude module.
+
+Validates that the Claude Agent SDK adapter wraps Device Connect tool functions
+with @claude_agent_sdk.tool and bundles them into an in-process MCP server.
+"""
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _install_claude_sdk_mock():
+    """Install a minimal mock of claude_agent_sdk before importing the adapter."""
+    sdk_mod = ModuleType("claude_agent_sdk")
+
+    def fake_tool(name, description, schema):
+        """Mock @tool(name, desc, schema) — returns a decorator that tags the handler."""
+
+        def decorator(fn):
+            wrapped = MagicMock(wraps=fn, __name__=name, __doc__=description)
+            wrapped._tool_name = name
+            wrapped._tool_schema = schema
+            wrapped.__wrapped__ = fn
+            return wrapped
+
+        return decorator
+
+    def fake_create_sdk_mcp_server(*args, **kwargs):
+        return {
+            "name": kwargs.get("name") or (args[0] if args else None),
+            "tools": kwargs.get("tools", []),
+        }
+
+    sdk_mod.tool = fake_tool
+    sdk_mod.create_sdk_mcp_server = fake_create_sdk_mcp_server
+    sys.modules["claude_agent_sdk"] = sdk_mod
+    return sdk_mod
+
+
+@pytest.fixture(autouse=True)
+def _mock_sdk_and_connection():
+    """Mock claude_agent_sdk and the Device Connect connection for all tests."""
+    _install_claude_sdk_mock()
+
+    mock_conn = MagicMock()
+    mock_conn.list_devices.return_value = []
+    mock_conn.invoke.return_value = {"jsonrpc": "2.0", "id": "1", "result": {}}
+    mock_conn.get_device.return_value = {"device_id": "dev-1", "device_type": "test"}
+
+    with patch(
+        "device_connect_agent_tools.tools.get_connection", return_value=mock_conn
+    ):
+        for mod_name in list(sys.modules):
+            if "device_connect_agent_tools.adapters.claude" in mod_name:
+                del sys.modules[mod_name]
+        yield mock_conn
+
+    sys.modules.pop("claude_agent_sdk", None)
+
+
+TOOL_NAMES = (
+    "describe_fleet",
+    "list_devices",
+    "get_device_functions",
+    "discover_devices",
+    "invoke_device",
+    "invoke_device_with_fallback",
+    "get_device_status",
+)
+
+
+class TestClaudeAdapterExports:
+    def test_module_exports_all_tools(self):
+        from device_connect_agent_tools.adapters import claude as adapter
+
+        for name in TOOL_NAMES:
+            assert hasattr(adapter, name), f"Missing export: {name}"
+        assert hasattr(adapter, "create_device_connect_server")
+
+    def test_all_list(self):
+        from device_connect_agent_tools.adapters import claude as adapter
+
+        expected = set(TOOL_NAMES) | {"create_device_connect_server"}
+        assert set(adapter.__all__) == expected
+
+    def test_tools_are_callable(self):
+        from device_connect_agent_tools.adapters import claude as adapter
+
+        for name in TOOL_NAMES:
+            assert callable(getattr(adapter, name)), f"{name} is not callable"
+
+    def test_tool_names_match(self):
+        from device_connect_agent_tools.adapters import claude as adapter
+
+        for name in TOOL_NAMES:
+            assert getattr(adapter, name)._tool_name == name
+
+    def test_create_server_bundles_all_tools(self):
+        from device_connect_agent_tools.adapters import claude as adapter
+
+        server = adapter.create_device_connect_server()
+        assert server["name"] == "device-connect"
+        bundled = {t._tool_name for t in server["tools"]}
+        assert bundled == set(TOOL_NAMES)


### PR DESCRIPTION
Adds a Claude Agent SDK adapter to `device-connect-agent-tools`, alongside the existing Strands and LangChain adapters.

- Wraps the hierarchical discovery tools (`describe_fleet`, `list_devices`, `get_device_functions`) and invocation tools as `claude_agent_sdk` tools, bundled via `create_device_connect_server()` for use in `ClaudeAgentOptions(mcp_servers=...)`
- Adds `[claude]` optional dependency extra
- Adds a Claude Agent SDK quick-start section to the README
- Adds `tests/test_claude_adapter.py` mirroring `test_strands_adapter.py` (mocks the SDK so CI doesn't need it installed)

**Testing:** 131 agent-tools unit tests pass; verified end-to-end against a local D2D sensor.