### PR TITLE
docs: update install instructions to use pip install from PyPI

### DIFF
--- a/packages/device-connect-agent-tools/README.md
+++ b/packages/device-connect-agent-tools/README.md
@@ -48,12 +48,10 @@ Framework-agnostic tools for Device Connect — discover and invoke devices from
 
 ## Install
 
-> Not yet on PyPI. Install from Git:
-
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install "device-connect-agent-tools @ git+https://github.com/arm/device-connect.git#subdirectory=packages/device-connect-agent-tools"
+pip install device-connect-agent-tools
 ```
 
 Optional extras:

--- a/packages/device-connect-server/README.md
+++ b/packages/device-connect-server/README.md
@@ -28,16 +28,13 @@ Server-side runtime for the Device Connect framework. Extends [device-connect-ed
 
 ## Install
 
-> Not yet on PyPI. Install from Git:
-
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -e "../device-connect-edge"
-pip install -e ".[all]"
+pip install device-connect-server
 ```
 
-This pulls in `device-connect-edge` automatically. Optional extras:
+Optional extras:
 
 | Extra | Adds |
 |-------|------|


### PR DESCRIPTION
## Summary
- Remove "Not yet on PyPI. Install from Git:" notes from `device-connect-agent-tools` and `device-connect-server` READMEs
- Replace with simple `pip install` commands consistent with the root README

Both packages are published on PyPI — the install docs were stale.