### PR TITLE
cd: add PyPI release workflow with trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+# Publishes all three packages to PyPI when a tag matching `v*` is pushed.
+# Uses PyPI Trusted Publishing (OIDC) — no stored tokens.
+#
+# Release procedure:
+#   1. Bump `version` in each packages/*/pyproject.toml (keep them in lockstep).
+#   2. Commit on main, then: git tag v0.2.3 && git push origin v0.2.3
+#   3. Approve the `pypi` environment deployment in the Actions UI.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to release (tag or SHA)'
+        required: true
+
+env:
+  PYTHON_VERSION: '3.12'
+
+jobs:
+  build:
+    name: Build ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        package:
+          - device-connect-edge
+          - device-connect-server
+          - device-connect-agent-tools
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version=$(grep -m1 '^version' "packages/${{ matrix.package }}/pyproject.toml" | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "Tag $tag_version != ${{ matrix.package }} version $pkg_version" >&2
+            exit 1
+          fi
+      - name: Build sdist + wheel
+        working-directory: packages/${{ matrix.package }}
+        run: python -m build
+      - name: Validate distributions
+        run: twine check packages/${{ matrix.package }}/dist/*
+      - uses: actions/upload-artifact@v5
+        with:
+          name: dist-${{ matrix.package }}
+          path: packages/${{ matrix.package }}/dist/
+          retention-days: 7
+
+  publish:
+    name: Publish ${{ matrix.package }}
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/${{ matrix.package }}/
+    permissions:
+      id-token: write  # OIDC token for Trusted Publishing
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - device-connect-edge
+          - device-connect-server
+          - device-connect-agent-tools
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: dist-${{ matrix.package }}
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          print-hash: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,20 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install build tools
         run: python -m pip install --upgrade build twine
-      - name: Verify tag matches package version
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Resolve release version
+        id: ver
         run: |
-          tag_version="${GITHUB_REF_NAME#v}"
-          pkg_version=$(grep -m1 '^version' "packages/${{ matrix.package }}/pyproject.toml" | sed -E 's/.*"([^"]+)".*/\1/')
-          if [ "$tag_version" != "$pkg_version" ]; then
-            echo "Tag $tag_version != ${{ matrix.package }} version $pkg_version" >&2
+          ref="${{ inputs.ref || github.ref_name }}"
+          case "$ref" in
+            v*) echo "version=${ref#v}" >> "$GITHUB_OUTPUT" ;;
+            *)  echo "Refusing to release non-tag ref: $ref" >&2; exit 1 ;;
+          esac
+      - name: Verify ref version matches package version
+        run: |
+          ref_version="${{ steps.ver.outputs.version }}"
+          pkg_version=$(python -c "import tomllib,sys; print(tomllib.load(open(sys.argv[1],'rb'))['project']['version'])" "packages/${{ matrix.package }}/pyproject.toml")
+          if [ "$ref_version" != "$pkg_version" ]; then
+            echo "Ref $ref_version != ${{ matrix.package }} version $pkg_version" >&2
             exit 1
           fi
       - name: Build sdist + wheel
@@ -70,7 +77,7 @@ jobs:
     permissions:
       id-token: write  # OIDC token for Trusted Publishing
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         package:
           - device-connect-edge


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` so a `vX.Y.Z` tag push publishes all three packages (`device-connect-edge`, `device-connect-server`, `device-connect-agent-tools`) to PyPI.

- **Trigger:** tag push matching `v*` (or `workflow_dispatch` with a ref).
- **Trusted Publishing (OIDC):** no stored tokens. PyPI projects are already configured with `arm/device-connect` + `release.yml` + `pypi` environment as the trusted publisher.
- **`pypi` environment:** deployments require reviewer approval (configured in repo Settings → Environments).
- **Version guard:** the job fails fast if the tag version doesn't match each package's `pyproject.toml` version, preventing mismatched releases.
- **Matrix:** builds and publishes the three packages in parallel; artifacts uploaded per package for traceability.

## Release procedure (after this merges)

1. Bump `version` in each `packages/*/pyproject.toml` in lockstep.
2. Merge to `main`.
3. `git tag -a vX.Y.Z -m "Release X.Y.Z" && git push origin vX.Y.Z`.
4. Approve the `pypi` environment deployment in the Actions UI.

## Context

Currently `main` is at 0.2.2 (published via a one-off `twine upload` today). PyPI and `main` drift was the motivation — going forward, PyPI only updates from tagged commits that pass the version guard.

## Test plan

- [ ] CI workflow (`ci.yml`) still runs on this PR and passes.