### PR TITLE
Add SPDX + Arm copyright headers across repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: CI
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Release
 
 # Publishes all three packages to PyPI when a tag matching `v*` is pushed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,3 +184,21 @@ See [tests/README.md](tests/README.md) for the full test matrix.
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).
+
+## File headers
+
+All source files contributed to this repository must include the following
+header at the top:
+
+```
+Copyright (c) <year>-2026, Arm Limited and Contributors. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+```
+
+For languages that use `/* */` or `//` comments (C, C++, Go, JavaScript,
+TypeScript, etc.), apply the equivalent block-comment form. For shebang
+scripts, place the header immediately after the shebang line.
+
+Preserve this header when editing existing files. If you are contributing
+code originally authored by a third party, preserve their original
+copyright notice verbatim and do not overwrite it.

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/__init__.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Device Connect Tools — framework-agnostic SDK for Device Connect IoT.
 
 Hierarchical discovery keeps LLM context small:

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/_normalize.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/_normalize.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared device normalization helpers.
 
 Operates on flat device dicts (already run through ``connection.flatten_device``

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/__init__.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Framework adapters for device-connect-agent-tools.
 
 Import tools from the adapter matching your agent framework:

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/claude.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/claude.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Claude Agent SDK adapter — exposes Device Connect tools to claude-agent-sdk.
 
 Hierarchical discovery keeps LLM context small::

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/langchain.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/langchain.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """LangChain adapter — wraps Device Connect tools as LangChain StructuredTools.
 
 Hierarchical discovery keeps LLM context small:

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/strands.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/strands.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Strands adapter — wraps Device Connect tools with @strands.tool.
 
 Hierarchical discovery keeps LLM context small:

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/strands_agent.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/strands_agent.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """StrandsDeviceConnectAgent — DeviceConnectAgent with a Strands backend.
 
 Usage::

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/agent.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/agent.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """DeviceConnectAgent — high-level agent that connects, discovers, and reacts to events.
 
 Usage::

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/connection.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/connection.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Messaging connection management for Device Connect tools.
 
 Uses device_connect_edge.messaging for the underlying connection, credential

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/__init__.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MCP Bridge for Device Connect.
 
 This module provides:

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/__main__.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/__main__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Entry point for MCP Bridge Server.
 
 Usage:

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/bridge.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/bridge.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MCP Bridge Server for Claude Desktop.
 
 Connects Claude Desktop to Device Connect devices by exposing 4 meta-tools

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/config.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/config.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Configuration for MCP Bridge and DeviceConnectMCP devices.
 
 Loads configuration from environment variables and credentials files.

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/device_connect_mcp.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/device_connect_mcp.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """DeviceConnectMCP - FastMCP-compatible API for Device Connect devices.
 
 Provides a simple, decorator-based interface for building Device Connect devices

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/device_tools.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/device_tools.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MCP server for remote device operations.
 
 This module provides an MCP server that exposes tools for interacting with

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/router.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/router.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tool router for MCP Bridge.
 
 Routes MCP tool calls to Device Connect devices via NATS JSON-RPC.

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/schema.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/schema.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MCP tool name parsing utilities."""
 
 from __future__ import annotations

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/tools.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/tools.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Device Connect device operations — framework-agnostic tool functions.
 
 Hierarchical discovery tools that keep LLM context small:

--- a/packages/device-connect-agent-tools/pyproject.toml
+++ b/packages/device-connect-agent-tools/pyproject.toml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/packages/device-connect-agent-tools/tests/__init__.py
+++ b/packages/device-connect-agent-tools/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/packages/device-connect-agent-tools/tests/conftest.py
+++ b/packages/device-connect-agent-tools/tests/conftest.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared fixtures for device-connect-agent-tools tests.
 
 Uses device_connect_edge.messaging.MessagingConfig for credential/TLS resolution.

--- a/packages/device-connect-agent-tools/tests/fuzz/conftest.py
+++ b/packages/device-connect-agent-tools/tests/fuzz/conftest.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Hypothesis configuration for agent-tools fuzz tests."""
 
 import os

--- a/packages/device-connect-agent-tools/tests/fuzz/fuzz_jsonrpc_parsing.py
+++ b/packages/device-connect-agent-tools/tests/fuzz/fuzz_jsonrpc_parsing.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Atheris fuzz target: JSON-RPC message parsing from connection layer.
 
 Run:

--- a/packages/device-connect-agent-tools/tests/fuzz/fuzz_schema.py
+++ b/packages/device-connect-agent-tools/tests/fuzz/fuzz_schema.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Atheris fuzz target: MCP tool name parsing.
 
 Run:

--- a/packages/device-connect-agent-tools/tests/fuzz/test_fuzz_jsonrpc_parsing.py
+++ b/packages/device-connect-agent-tools/tests/fuzz/test_fuzz_jsonrpc_parsing.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Property-based fuzz tests for JSON-RPC message parsing in connection layer.
 
 Run:

--- a/packages/device-connect-agent-tools/tests/fuzz/test_fuzz_schema.py
+++ b/packages/device-connect-agent-tools/tests/fuzz/test_fuzz_schema.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Property-based fuzz tests for MCP tool name parsing.
 
 Run:

--- a/packages/device-connect-agent-tools/tests/test_claude_adapter.py
+++ b/packages/device-connect-agent-tools/tests/test_claude_adapter.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_agent_tools.adapters.claude module.
 
 Validates that the Claude Agent SDK adapter wraps Device Connect tool functions

--- a/packages/device-connect-agent-tools/tests/test_connection_unit.py
+++ b/packages/device-connect-agent-tools/tests/test_connection_unit.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_agent_tools.connection module.
 
 Tests connection management, config resolution, and RPC helpers

--- a/packages/device-connect-agent-tools/tests/test_integration.py
+++ b/packages/device-connect-agent-tools/tests/test_integration.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for device-connect-agent-tools.
 
 No dependency on device-connect-server — tests the standalone package.

--- a/packages/device-connect-agent-tools/tests/test_langchain_adapter.py
+++ b/packages/device-connect-agent-tools/tests/test_langchain_adapter.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_agent_tools.adapters.langchain module.
 
 Validates that the LangChain adapter correctly wraps Device Connect tool functions

--- a/packages/device-connect-agent-tools/tests/test_normalize.py
+++ b/packages/device-connect-agent-tools/tests/test_normalize.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_agent_tools._normalize."""
 from device_connect_agent_tools._normalize import (
     _normalize_events,

--- a/packages/device-connect-agent-tools/tests/test_strands_adapter.py
+++ b/packages/device-connect-agent-tools/tests/test_strands_adapter.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_agent_tools.adapters.strands module.
 
 Validates that the Strands adapter correctly wraps Device Connect tool functions

--- a/packages/device-connect-agent-tools/tests/test_tools_unit.py
+++ b/packages/device-connect-agent-tools/tests/test_tools_unit.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_agent_tools.tools module.
 
 Tests discover_devices, invoke_device, invoke_device_with_fallback,

--- a/packages/device-connect-edge/device_connect_edge/__init__.py
+++ b/packages/device-connect-edge/device_connect_edge/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Device Connect Edge — lightweight runtime for edge devices.
 
 Build IoT devices with Python. Connect them over Zenoh or NATS. Communicate

--- a/packages/device-connect-edge/device_connect_edge/device.py
+++ b/packages/device-connect-edge/device_connect_edge/device.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Helper for creating Device Connect devices.
 
 Provides resilient messaging connectivity, automatic device registration with retries,

--- a/packages/device-connect-edge/device_connect_edge/discovery.py
+++ b/packages/device-connect-edge/device_connect_edge/discovery.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Device-to-device discovery via presence announcements.
 
 When no infrastructure (registry, etcd, router) is available, devices can

--- a/packages/device-connect-edge/device_connect_edge/discovery_provider.py
+++ b/packages/device-connect-edge/device_connect_edge/discovery_provider.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Discovery provider protocol for unified device discovery.
 
 Defines the ``DiscoveryProvider`` protocol that both D2D (local presence)

--- a/packages/device-connect-edge/device_connect_edge/drivers/__init__.py
+++ b/packages/device-connect-edge/device_connect_edge/drivers/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Device driver framework for Device Connect.
 
 This module provides the foundation for implementing device-specific logic.

--- a/packages/device-connect-edge/device_connect_edge/drivers/base.py
+++ b/packages/device-connect-edge/device_connect_edge/drivers/base.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Device driver abstract base class with D2D communication.
 
 This module defines the DeviceDriver ABC, which provides the foundation

--- a/packages/device-connect-edge/device_connect_edge/drivers/capability_loader.py
+++ b/packages/device-connect-edge/device_connect_edge/drivers/capability_loader.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """In-process capability loading for Device Connect devices.
 
 This module provides infrastructure for loading capabilities from disk

--- a/packages/device-connect-edge/device_connect_edge/drivers/decorators.py
+++ b/packages/device-connect-edge/device_connect_edge/drivers/decorators.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Decorators for defining device functions and events.
 
 This module provides decorators that mark methods as device functions or

--- a/packages/device-connect-edge/device_connect_edge/drivers/transport.py
+++ b/packages/device-connect-edge/device_connect_edge/drivers/transport.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Lightweight transport wrapper for hardware-native topic access.
 
 Exposes raw publish/subscribe on arbitrary topics using the device's

--- a/packages/device-connect-edge/device_connect_edge/errors.py
+++ b/packages/device-connect-edge/device_connect_edge/errors.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Exception hierarchy for Device Connect.
 
 This module defines the exception classes used throughout the Device Connect

--- a/packages/device-connect-edge/device_connect_edge/messaging/__init__.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Messaging abstraction layer for Device Connect.
 

--- a/packages/device-connect-edge/device_connect_edge/messaging/base.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/base.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Abstract base class for messaging clients.
 

--- a/packages/device-connect-edge/device_connect_edge/messaging/config.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/config.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Configuration utilities for messaging layer.
 """

--- a/packages/device-connect-edge/device_connect_edge/messaging/exceptions.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/exceptions.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Custom exceptions for the messaging abstraction layer.
 """

--- a/packages/device-connect-edge/device_connect_edge/messaging/mqtt_adapter.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/mqtt_adapter.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 MQTT implementation of the messaging abstraction layer.
 """

--- a/packages/device-connect-edge/device_connect_edge/messaging/nats_adapter.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/nats_adapter.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 NATS implementation of the messaging abstraction layer.
 """

--- a/packages/device-connect-edge/device_connect_edge/messaging/zenoh_adapter.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/zenoh_adapter.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Zenoh implementation of the messaging abstraction layer.
 

--- a/packages/device-connect-edge/device_connect_edge/registry_client.py
+++ b/packages/device-connect-edge/device_connect_edge/registry_client.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Lightweight registry client for device discovery via JSON-RPC.
 
 Sends ``discovery/listDevices`` and ``discovery/getDevice`` requests

--- a/packages/device-connect-edge/device_connect_edge/telemetry/__init__.py
+++ b/packages/device-connect-edge/device_connect_edge/telemetry/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """OpenTelemetry integration for Device Connect.
 
 Provides distributed tracing, metrics, and context propagation

--- a/packages/device-connect-edge/device_connect_edge/telemetry/config.py
+++ b/packages/device-connect-edge/device_connect_edge/telemetry/config.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """DeviceConnectTelemetry — OpenTelemetry SDK setup for Device Connect.
 
 Aligned with strands.telemetry.StrandsTelemetry:

--- a/packages/device-connect-edge/device_connect_edge/telemetry/file_buffer_exporter.py
+++ b/packages/device-connect-edge/device_connect_edge/telemetry/file_buffer_exporter.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Disk-backed SpanExporter for connectivity resilience.
 
 Wraps a delegate SpanExporter (typically OTLP) and adds automatic

--- a/packages/device-connect-edge/device_connect_edge/telemetry/metrics.py
+++ b/packages/device-connect-edge/device_connect_edge/telemetry/metrics.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MetricsClient singleton for Device Connect.
 
 Aligned with strands.telemetry.MetricsClient — singleton pattern

--- a/packages/device-connect-edge/device_connect_edge/telemetry/propagation.py
+++ b/packages/device-connect-edge/device_connect_edge/telemetry/propagation.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """W3C TraceContext propagation through _dc_meta dicts.
 
 Injects/extracts traceparent and tracestate into the _dc_meta

--- a/packages/device-connect-edge/device_connect_edge/telemetry/tracer.py
+++ b/packages/device-connect-edge/device_connect_edge/telemetry/tracer.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Singleton tracer and span helpers for Device Connect.
 
 Aligned with strands.telemetry.tracer — singleton get_tracer() pattern

--- a/packages/device-connect-edge/device_connect_edge/types.py
+++ b/packages/device-connect-edge/device_connect_edge/types.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Core type definitions for Device Connect.
 
 This module defines the fundamental data structures used throughout the

--- a/packages/device-connect-edge/examples/dht22_sensor/device_driver.py
+++ b/packages/device-connect-edge/examples/dht22_sensor/device_driver.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """DHT22 Temperature & Humidity Sensor driver.
 
 This driver runs as a Python process on the physical device (e.g. Raspberry Pi).

--- a/packages/device-connect-edge/examples/number_generator/device_simulator.py
+++ b/packages/device-connect-edge/examples/number_generator/device_simulator.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Number Generator device simulator.
 
 A simulated IoT device that periodically emits random numbers as events.

--- a/packages/device-connect-edge/examples/string_generator/device_simulator.py
+++ b/packages/device-connect-edge/examples/string_generator/device_simulator.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """String Generator device simulator — uses Device Connect SDK constructs.
 
 A simulated IoT device that periodically emits random string fragments

--- a/packages/device-connect-edge/pyproject.toml
+++ b/packages/device-connect-edge/pyproject.toml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/packages/device-connect-edge/tests/__init__.py
+++ b/packages/device-connect-edge/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/packages/device-connect-edge/tests/fuzz/conftest.py
+++ b/packages/device-connect-edge/tests/fuzz/conftest.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Hypothesis configuration for fuzz tests.
 
 Profiles: 'default' for local dev, 'ci' for thorough CI runs.

--- a/packages/device-connect-edge/tests/fuzz/fuzz_credentials_json.py
+++ b/packages/device-connect-edge/tests/fuzz/fuzz_credentials_json.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Fuzz target: JSON credentials file loader.
 
 Exercises MessagingConfig._load_credentials_file() which parses JSON

--- a/packages/device-connect-edge/tests/fuzz/fuzz_jsonrpc_cmd.py
+++ b/packages/device-connect-edge/tests/fuzz/fuzz_jsonrpc_cmd.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Fuzz target: JSON-RPC command message parsing.
 
 Exercises the same parsing path as DeviceRuntime._cmd_subscription().on_msg(),

--- a/packages/device-connect-edge/tests/fuzz/fuzz_nats_creds.py
+++ b/packages/device-connect-edge/tests/fuzz/fuzz_nats_creds.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Fuzz target: NATS .creds file parser.
 
 Exercises MessagingConfig._parse_nats_creds_file() which uses manual

--- a/packages/device-connect-edge/tests/fuzz/fuzz_pydantic_models.py
+++ b/packages/device-connect-edge/tests/fuzz/fuzz_pydantic_models.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Fuzz target: Pydantic model validation.
 
 Exercises all core Pydantic models (DeviceIdentity, DeviceStatus,

--- a/packages/device-connect-edge/tests/fuzz/report_hypothesis.py
+++ b/packages/device-connect-edge/tests/fuzz/report_hypothesis.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Parse JUnit XML from hypothesis fuzz tests and output a GitHub-flavored markdown summary.
 
 Usage:

--- a/packages/device-connect-edge/tests/fuzz/run_atheris.py
+++ b/packages/device-connect-edge/tests/fuzz/run_atheris.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Runner for all atheris fuzz targets with markdown report generation.
 
 Runs each fuzz target across all packages, captures results, and writes

--- a/packages/device-connect-edge/tests/fuzz/test_fuzz_credentials_json.py
+++ b/packages/device-connect-edge/tests/fuzz/test_fuzz_credentials_json.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Property-based fuzz tests for JSON credentials file loader.
 
 Run:

--- a/packages/device-connect-edge/tests/fuzz/test_fuzz_jsonrpc_cmd.py
+++ b/packages/device-connect-edge/tests/fuzz/test_fuzz_jsonrpc_cmd.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Property-based fuzz tests for JSON-RPC command parsing.
 
 Uses hypothesis for portable, pytest-integrated fuzzing.

--- a/packages/device-connect-edge/tests/fuzz/test_fuzz_nats_creds.py
+++ b/packages/device-connect-edge/tests/fuzz/test_fuzz_nats_creds.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Property-based fuzz tests for NATS .creds file parser.
 
 Run:

--- a/packages/device-connect-edge/tests/fuzz/test_fuzz_pydantic_models.py
+++ b/packages/device-connect-edge/tests/fuzz/test_fuzz_pydantic_models.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Property-based fuzz tests for Pydantic model validation.
 
 Run:

--- a/packages/device-connect-edge/tests/test_capability_loader.py
+++ b/packages/device-connect-edge/tests/test_capability_loader.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_edge.drivers.capability_loader module.
 
 Tests cover:

--- a/packages/device-connect-edge/tests/test_device.py
+++ b/packages/device-connect-edge/tests/test_device.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_edge.device module.
 
 Tests DeviceRuntime lifecycle, build_rpc_response/build_rpc_error helpers,

--- a/packages/device-connect-edge/tests/test_discovery.py
+++ b/packages/device-connect-edge/tests/test_discovery.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_edge.discovery module.
 
 Tests PresenceAnnouncer, PresenceCollector, and D2DRegistry

--- a/packages/device-connect-edge/tests/test_driver_transport.py
+++ b/packages/device-connect-edge/tests/test_driver_transport.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for DriverTransport — raw messaging transport for DeviceDriver."""
 
 from unittest.mock import AsyncMock, MagicMock

--- a/packages/device-connect-edge/tests/test_drivers.py
+++ b/packages/device-connect-edge/tests/test_drivers.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_edge.drivers module.
 
 Tests @rpc, @emit, @on decorators, schema generation, and DeviceDriver base class.

--- a/packages/device-connect-edge/tests/test_errors.py
+++ b/packages/device-connect-edge/tests/test_errors.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_edge.errors module."""
 
 from device_connect_edge.errors import (

--- a/packages/device-connect-edge/tests/test_file_buffer_exporter.py
+++ b/packages/device-connect-edge/tests/test_file_buffer_exporter.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for device_connect_edge.telemetry.file_buffer_exporter module."""
 
 import json

--- a/packages/device-connect-edge/tests/test_messaging_base.py
+++ b/packages/device-connect-edge/tests/test_messaging_base.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_edge.messaging.base -- MessagingClient ABC contract.
 
 Validates that the abstract interface is correctly defined and that

--- a/packages/device-connect-edge/tests/test_messaging_config.py
+++ b/packages/device-connect-edge/tests/test_messaging_config.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_edge.messaging.config module."""
 
 import os

--- a/packages/device-connect-edge/tests/test_messaging_exceptions.py
+++ b/packages/device-connect-edge/tests/test_messaging_exceptions.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for device_connect_edge.messaging.exceptions module."""
 
 from device_connect_edge.messaging.exceptions import (

--- a/packages/device-connect-edge/tests/test_mqtt_adapter.py
+++ b/packages/device-connect-edge/tests/test_mqtt_adapter.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_edge.messaging.mqtt_adapter — MQTTAdapter.
 
 The ``aiomqtt`` library is fully mocked so no real MQTT broker is needed.

--- a/packages/device-connect-edge/tests/test_nats_adapter.py
+++ b/packages/device-connect-edge/tests/test_nats_adapter.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_edge.messaging.nats_adapter — NATSAdapter.
 
 All NATS client internals are mocked so no real NATS server is needed.

--- a/packages/device-connect-edge/tests/test_registry_client.py
+++ b/packages/device-connect-edge/tests/test_registry_client.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_edge.registry_client module.
 
 Tests RegistryClient._request retry logic with mocked messaging.

--- a/packages/device-connect-edge/tests/test_telemetry.py
+++ b/packages/device-connect-edge/tests/test_telemetry.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for the device_connect_edge.telemetry package.
 
 Tests cover:

--- a/packages/device-connect-edge/tests/test_types.py
+++ b/packages/device-connect-edge/tests/test_types.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_edge.types module."""
 
 from device_connect_edge.types import (

--- a/packages/device-connect-edge/tests/test_wait_for_device.py
+++ b/packages/device-connect-edge/tests/test_wait_for_device.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for DeviceDriver.wait_for_device() and depends_on startup gating."""
 
 import pytest

--- a/packages/device-connect-edge/tests/test_zenoh_adapter.py
+++ b/packages/device-connect-edge/tests/test_zenoh_adapter.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_edge.messaging.zenoh_adapter — ZenohAdapter.
 
 All Zenoh SDK internals are mocked so no real Zenoh session is needed.

--- a/packages/device-connect-server/device_connect_server/__init__.py
+++ b/packages/device-connect-server/device_connect_server/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Device Connect Server — infrastructure extensions for Device Connect.
 
 Device-side logic (DeviceRuntime, DeviceDriver, messaging, types) lives in

--- a/packages/device-connect-server/device_connect_server/devctl/__init__.py
+++ b/packages/device-connect-server/device_connect_server/devctl/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Device control CLI for Device Connect.
 
 This module provides a command-line interface for interacting with

--- a/packages/device-connect-server/device_connect_server/devctl/__main__.py
+++ b/packages/device-connect-server/device_connect_server/devctl/__main__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Entry point for running devctl as a module.
 
 Usage:

--- a/packages/device-connect-server/device_connect_server/devctl/cli.py
+++ b/packages/device-connect-server/device_connect_server/devctl/cli.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """CLI for Device Connect device control.
 
 This module provides the command-line interface for device operations:

--- a/packages/device-connect-server/device_connect_server/logging/__init__.py
+++ b/packages/device-connect-server/device_connect_server/logging/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Logging framework for Device Connect.
 
 This module provides pluggable audit logging with multiple backend support.

--- a/packages/device-connect-server/device_connect_server/logging/base.py
+++ b/packages/device-connect-server/device_connect_server/logging/base.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Abstract base class for audit logging.
 
 This module defines the AuditLogger interface for pluggable logging

--- a/packages/device-connect-server/device_connect_server/logging/mongo.py
+++ b/packages/device-connect-server/device_connect_server/logging/mongo.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MongoDB implementation of the AuditLogger.
 
 This module provides MongoAuditLogger, which stores audit logs in

--- a/packages/device-connect-server/device_connect_server/portal/__init__.py
+++ b/packages/device-connect-server/device_connect_server/portal/__init__.py
@@ -1,1 +1,5 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Device Connect Tenant Management Portal."""

--- a/packages/device-connect-server/device_connect_server/portal/__main__.py
+++ b/packages/device-connect-server/device_connect_server/portal/__main__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Entry point: python -m device_connect_server.portal"""
 
 import logging

--- a/packages/device-connect-server/device_connect_server/portal/app.py
+++ b/packages/device-connect-server/device_connect_server/portal/app.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """aiohttp application factory with session middleware and route registration."""
 
 import base64

--- a/packages/device-connect-server/device_connect_server/portal/config.py
+++ b/packages/device-connect-server/device_connect_server/portal/config.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Portal configuration — paths, env vars, defaults."""
 
 import os

--- a/packages/device-connect-server/device_connect_server/portal/services/__init__.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/packages/device-connect-server/device_connect_server/portal/services/backend.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/backend.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Messaging backend abstraction — strategy pattern for NATS, Zenoh, and MQTT.
 
 The admin selects a backend during bootstrap. All portal services

--- a/packages/device-connect-server/device_connect_server/portal/services/bundles.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/bundles.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Create and serve tenant credential bundles (.zip)."""
 
 import io

--- a/packages/device-connect-server/device_connect_server/portal/services/credentials.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/credentials.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Read and list credential JSON files from the credentials directory."""
 
 import json

--- a/packages/device-connect-server/device_connect_server/portal/services/mqtt_acl.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/mqtt_acl.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Mosquitto password file and ACL management for tenant isolation."""
 
 import asyncio

--- a/packages/device-connect-server/device_connect_server/portal/services/mqtt_admin.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/mqtt_admin.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Mosquitto broker reload via Docker container SIGHUP."""
 
 import asyncio

--- a/packages/device-connect-server/device_connect_server/portal/services/mqtt_backend.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/mqtt_backend.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MQTT backend \u2014 Mosquitto password file + ACL for tenant isolation."""
 
 import json

--- a/packages/device-connect-server/device_connect_server/portal/services/mqtt_rpc.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/mqtt_rpc.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MQTT helpers: RPC invocation and event streaming using MQTTAdapter."""
 
 import json

--- a/packages/device-connect-server/device_connect_server/portal/services/nats_admin.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/nats_admin.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """NATS config regeneration and container reload."""
 
 import asyncio

--- a/packages/device-connect-server/device_connect_server/portal/services/nats_backend.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/nats_backend.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """NATS backend — delegates to existing nsc, nats_admin, nats_rpc modules."""
 
 import logging

--- a/packages/device-connect-server/device_connect_server/portal/services/nats_rpc.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/nats_rpc.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """NATS helpers: RPC invocation and event streaming."""
 
 import json

--- a/packages/device-connect-server/device_connect_server/portal/services/nsc.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/nsc.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Wraps the nsc CLI for NATS JWT credential management."""
 
 import asyncio

--- a/packages/device-connect-server/device_connect_server/portal/services/registry_client.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/registry_client.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Query the device registry for live device data via etcd."""
 
 import json

--- a/packages/device-connect-server/device_connect_server/portal/services/users.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/users.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """User account management backed by etcd."""
 
 import json

--- a/packages/device-connect-server/device_connect_server/portal/services/verification.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/verification.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Port of verify_tenants.sh — test tenant isolation."""
 
 import asyncio

--- a/packages/device-connect-server/device_connect_server/portal/services/zenoh_acl.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/zenoh_acl.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Zenoh ACL config management — generates and updates Zenoh router config.
 
 The Zenoh 1.0 ACL plugin enforces access control based on TLS certificate CN

--- a/packages/device-connect-server/device_connect_server/portal/services/zenoh_admin.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/zenoh_admin.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Zenoh router lifecycle — config reload via Docker container restart."""
 
 import asyncio

--- a/packages/device-connect-server/device_connect_server/portal/services/zenoh_backend.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/zenoh_backend.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Zenoh backend — mTLS certificates + ACL plugin for tenant isolation."""
 
 import json

--- a/packages/device-connect-server/device_connect_server/portal/services/zenoh_pki.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/zenoh_pki.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Zenoh PKI — certificate generation via openssl subprocess.
 
 Generates:

--- a/packages/device-connect-server/device_connect_server/portal/services/zenoh_rpc.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/zenoh_rpc.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Zenoh helpers: RPC invocation and event streaming using ZenohAdapter."""
 
 import json

--- a/packages/device-connect-server/device_connect_server/portal/views/__init__.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/packages/device-connect-server/device_connect_server/portal/views/admin.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/admin.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Admin views: dashboard, view-as-user, health check, setup, broker reload."""
 
 import html as _html

--- a/packages/device-connect-server/device_connect_server/portal/views/auth.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/auth.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Authentication views: login, signup, logout."""
 
 import html as _html

--- a/packages/device-connect-server/device_connect_server/portal/views/dashboard.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/dashboard.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """User dashboard with live device polling, RPC invocation, and event streaming."""
 
 import asyncio

--- a/packages/device-connect-server/device_connect_server/portal/views/devices.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/devices.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Device management views: create, list, download credentials and bundles."""
 
 import html as _html

--- a/packages/device-connect-server/device_connect_server/registry/__init__.py
+++ b/packages/device-connect-server/device_connect_server/registry/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Registry client for Device Connect.
 
 This module provides the RegistryClient for querying the device registry.

--- a/packages/device-connect-server/device_connect_server/registry/client.py
+++ b/packages/device-connect-server/device_connect_server/registry/client.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Registry client for querying registered devices.
 
 This module provides RegistryClient, which communicates with the

--- a/packages/device-connect-server/device_connect_server/registry/service/__init__.py
+++ b/packages/device-connect-server/device_connect_server/registry/service/__init__.py
@@ -1,1 +1,5 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Empty; package marker

--- a/packages/device-connect-server/device_connect_server/registry/service/main.py
+++ b/packages/device-connect-server/device_connect_server/registry/service/main.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Device Registry Service.
 

--- a/packages/device-connect-server/device_connect_server/registry/service/registry.py
+++ b/packages/device-connect-server/device_connect_server/registry/service/registry.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Light-weight interface to etcd for storing device information.
 
 This module exposes simple helper functions that wrap the ``etcd3gw`` client

--- a/packages/device-connect-server/device_connect_server/security/__init__.py
+++ b/packages/device-connect-server/device_connect_server/security/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Security module for Device Connect.
 
 This module provides security-related functionality including:

--- a/packages/device-connect-server/device_connect_server/security/acl.py
+++ b/packages/device-connect-server/device_connect_server/security/acl.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Access Control List (ACL) models and utilities for Device Connect.
 

--- a/packages/device-connect-server/device_connect_server/security/commissioning.py
+++ b/packages/device-connect-server/device_connect_server/security/commissioning.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Device commissioning module for Device Connect.
 

--- a/packages/device-connect-server/device_connect_server/security/credentials.py
+++ b/packages/device-connect-server/device_connect_server/security/credentials.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Credential loading and validation for Device Connect.
 
 This module provides utilities for loading device credentials from

--- a/packages/device-connect-server/device_connect_server/state/__init__.py
+++ b/packages/device-connect-server/device_connect_server/state/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """State management for Device Connect.
 
 This module provides the StateStore ABC for key-value state storage

--- a/packages/device-connect-server/device_connect_server/state/base.py
+++ b/packages/device-connect-server/device_connect_server/state/base.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """State store abstract base class.
 
 This module defines the StateStore ABC, which provides a pluggable

--- a/packages/device-connect-server/device_connect_server/state/etcd_store.py
+++ b/packages/device-connect-server/device_connect_server/state/etcd_store.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """EtcdStateStore — concrete StateStore implementation backed by etcd3.
 
 This module provides a production-ready state store using etcd3 via the

--- a/packages/device-connect-server/device_connect_server/statectl/__init__.py
+++ b/packages/device-connect-server/device_connect_server/statectl/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """State store CLI for Device Connect.
 
 This module provides a command-line interface for inspecting and managing

--- a/packages/device-connect-server/device_connect_server/statectl/__main__.py
+++ b/packages/device-connect-server/device_connect_server/statectl/__main__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Entry point for running statectl as a module.
 
 Usage:

--- a/packages/device-connect-server/device_connect_server/statectl/cli.py
+++ b/packages/device-connect-server/device_connect_server/statectl/cli.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """CLI for inspecting and managing etcd state in Device Connect.
 
 A Python-native replacement for etcdctl, tailored for the Device Connect

--- a/packages/device-connect-server/docker-compose-dev.yml
+++ b/packages/device-connect-server/docker-compose-dev.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 services:
   nats:
     image: nats:2.10

--- a/packages/device-connect-server/docker-compose.dev.yml
+++ b/packages/device-connect-server/docker-compose.dev.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 services:
   nats:
     image: nats:2.10

--- a/packages/device-connect-server/docker-compose.yml
+++ b/packages/device-connect-server/docker-compose.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 services:
   nats-jwt:
     image: nats:2.10

--- a/packages/device-connect-server/infra/docker-compose-dev.yml
+++ b/packages/device-connect-server/infra/docker-compose-dev.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Zenoh-based development infrastructure (default).
 # No TLS, no auth. Use with DEVICE_CONNECT_ALLOW_INSECURE=true.
 #

--- a/packages/device-connect-server/infra/docker-compose-multitenant-mqtt.yml
+++ b/packages/device-connect-server/infra/docker-compose-multitenant-mqtt.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Multi-tenant infrastructure: MQTT (Mosquitto password + ACL) + etcd + device registry.
 #
 # Prerequisites:

--- a/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
+++ b/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Multi-tenant infrastructure: NATS (JWT auth) + etcd + device registry.
 #
 # Prerequisites:

--- a/packages/device-connect-server/infra/docker-compose-multitenant-zenoh.yml
+++ b/packages/device-connect-server/infra/docker-compose-multitenant-zenoh.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Multi-tenant infrastructure: Zenoh (mTLS + ACL) + etcd + device registry.
 #
 # Prerequisites:

--- a/packages/device-connect-server/infra/docker-compose-nats-dev.yml
+++ b/packages/device-connect-server/infra/docker-compose-nats-dev.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # NATS-based development infrastructure.
 # No TLS, no JWT auth. Use with DEVICE_CONNECT_ALLOW_INSECURE=true.
 #

--- a/packages/device-connect-server/infra/docker-compose-nats.yml
+++ b/packages/device-connect-server/infra/docker-compose-nats.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # NATS-based production infrastructure (JWT + TLS).
 #
 # Requires:

--- a/packages/device-connect-server/infra/docker-compose.yml
+++ b/packages/device-connect-server/infra/docker-compose.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Zenoh-based production infrastructure (TLS).
 #
 # Requires TLS certificates in security_infra/:

--- a/packages/device-connect-server/pyproject.toml
+++ b/packages/device-connect-server/pyproject.toml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/packages/device-connect-server/security_infra/gen_creds.sh
+++ b/packages/device-connect-server/security_infra/gen_creds.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Generate NATS JWT credentials for Device Connect services and devices.
 #

--- a/packages/device-connect-server/security_infra/generate_tls_certs.sh
+++ b/packages/device-connect-server/security_infra/generate_tls_certs.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Generate TLS certificates for Device Connect infrastructure.
 #

--- a/packages/device-connect-server/security_infra/manage_tenants.sh
+++ b/packages/device-connect-server/security_infra/manage_tenants.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Manage tenants and device tokens for multi-tenant Device Connect deployments.
 #

--- a/packages/device-connect-server/security_infra/setup_deployment.sh
+++ b/packages/device-connect-server/security_infra/setup_deployment.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # One-time setup of multi-tenant NATS JWT infrastructure + privileged credentials.
 #

--- a/packages/device-connect-server/security_infra/setup_jwt_auth.sh
+++ b/packages/device-connect-server/security_infra/setup_jwt_auth.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Setup NATS JWT authentication infrastructure using nsc.
 #

--- a/packages/device-connect-server/security_infra/verify_tenants.sh
+++ b/packages/device-connect-server/security_infra/verify_tenants.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Verify multi-tenant isolation: test that per-tenant NATS JWT permissions work.
 #

--- a/packages/device-connect-server/tests/__init__.py
+++ b/packages/device-connect-server/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/packages/device-connect-server/tests/device_connect_server/__init__.py
+++ b/packages/device-connect-server/tests/device_connect_server/__init__.py
@@ -1,1 +1,5 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Device Connect Server tests."""

--- a/packages/device-connect-server/tests/device_connect_server/test_agentic_driver.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_agentic_driver.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for D2D (device-to-device) communication in DeviceDriver."""
 import pytest
 from unittest.mock import AsyncMock, MagicMock

--- a/packages/device-connect-server/tests/device_connect_server/test_devctl_cli.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_devctl_cli.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for device_connect_server.devctl.cli module."""
 
 import json

--- a/packages/device-connect-server/tests/device_connect_server/test_drivers.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_drivers.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for device driver decorators (rpc, emit, periodic, before_emit)."""
 import asyncio
 import pytest

--- a/packages/device-connect-server/tests/device_connect_server/test_etcd_state_store.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_etcd_state_store.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for EtcdStateStore.
 
 Tests can run as integration tests against a real etcd instance

--- a/packages/device-connect-server/tests/device_connect_server/test_logging.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_logging.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for device_connect_server.logging module."""
 import pytest
 from device_connect_server.logging import (

--- a/packages/device-connect-server/tests/device_connect_server/test_registry_client.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_registry_client.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_server.registry.client.RegistryClient.
 
 Tests use a mocked MessagingClient — no real NATS required.

--- a/packages/device-connect-server/tests/device_connect_server/test_registry_service.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_registry_service.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for device_connect_server.registry.service.registry — DeviceRegistry.
 
 The ``etcd3gw`` client is fully mocked so no real etcd server is needed.

--- a/packages/device-connect-server/tests/device_connect_server/test_rpc_handlers.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_rpc_handlers.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for registry service RPC handler factories.
 
 Tests the three handler factories in

--- a/packages/device-connect-server/tests/device_connect_server/test_security_acl.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_security_acl.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for device_connect_server.security.acl module."""
 
 from device_connect_server.security.acl import (

--- a/packages/device-connect-server/tests/device_connect_server/test_security_commissioning.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_security_commissioning.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for device_connect_server.security.commissioning module."""
 
 import json

--- a/packages/device-connect-server/tests/device_connect_server/test_security_credentials.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_security_credentials.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for device_connect_server.security.credentials module."""
 
 import json

--- a/packages/device-connect-server/tests/device_connect_server/test_statectl_cli.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_statectl_cli.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for device_connect_server.statectl.cli helper functions."""
 
 import base64

--- a/packages/device-connect-server/tests/fuzz/conftest.py
+++ b/packages/device-connect-server/tests/fuzz/conftest.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Hypothesis configuration for server fuzz tests."""
 
 import os

--- a/packages/device-connect-server/tests/fuzz/fuzz_commissioning.py
+++ b/packages/device-connect-server/tests/fuzz/fuzz_commissioning.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Atheris fuzz target: PIN parsing.
 
 Run:

--- a/packages/device-connect-server/tests/fuzz/fuzz_credentials.py
+++ b/packages/device-connect-server/tests/fuzz/fuzz_credentials.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Atheris fuzz target: server CredentialsLoader.
 
 Run:

--- a/packages/device-connect-server/tests/fuzz/test_fuzz_commissioning.py
+++ b/packages/device-connect-server/tests/fuzz/test_fuzz_commissioning.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Property-based fuzz tests for PIN parsing.
 
 Run:

--- a/packages/device-connect-server/tests/fuzz/test_fuzz_credentials.py
+++ b/packages/device-connect-server/tests/fuzz/test_fuzz_credentials.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Property-based fuzz tests for server CredentialsLoader.
 
 Run:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,1 +1,5 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 line-length = 120

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Root conftest for cross-repo integration tests.
 
 Infrastructure:

--- a/tests/docker-compose-itest.yml
+++ b/tests/docker-compose-itest.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Docker Compose for cross-repo integration tests.
 # Dev mode: no TLS, no JWT auth. Matches DEVICE_CONNECT_ALLOW_INSECURE=true.
 #

--- a/tests/drivers/__init__.py
+++ b/tests/drivers/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/tests/drivers/camera.py
+++ b/tests/drivers/camera.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test camera driver using device_connect_edge (device-connect-edge).
 
 Validates the edge SDK package by importing from device_connect_edge.drivers.

--- a/tests/drivers/robot.py
+++ b/tests/drivers/robot.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test robot driver using device_connect_edge (device-connect-edge).
 
 Validates the edge SDK package by importing from device_connect_edge.drivers.

--- a/tests/drivers/sensor.py
+++ b/tests/drivers/sensor.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test sensor driver using device_connect_edge (device-connect-edge).
 
 Validates the edge SDK package by importing from device_connect_edge.drivers.

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/tests/fixtures/devices.py
+++ b/tests/fixtures/devices.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Device spawning fixtures for cross-repo integration tests.
 
 Uses device_connect_edge (device-connect-edge) — validates the edge SDK package.

--- a/tests/fixtures/events.py
+++ b/tests/fixtures/events.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Event capture and assertion utilities for cross-repo integration tests.
 
 Uses the SDK MessagingClient abstraction — supports NATS, Zenoh, and MQTT backends.

--- a/tests/fixtures/infrastructure.py
+++ b/tests/fixtures/infrastructure.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Docker Compose infrastructure management for cross-repo integration tests.
 
 Manages NATS + Zenoh + etcd + device-registry-service lifecycle.

--- a/tests/fixtures/inject.py
+++ b/tests/fixtures/inject.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Event injection utilities for cross-repo integration tests.
 
 Uses the SDK MessagingClient abstraction — supports NATS, Zenoh, and MQTT backends.

--- a/tests/fixtures/orchestrator.py
+++ b/tests/fixtures/orchestrator.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Orchestrator fixtures for cross-repo integration tests.
 
 - MockOrchestrator: Rule-based routing (no LLM, fast)

--- a/tests/tests/__init__.py
+++ b/tests/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/tests/tests/test_d2d_discovery.py
+++ b/tests/tests/test_d2d_discovery.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for D2D device discovery (no Docker infrastructure).
 
 Tests that devices can discover each other and communicate via Zenoh

--- a/tests/tests/test_d2d_events.py
+++ b/tests/tests/test_d2d_events.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for D2D (Device-to-Device) event subscription.
 
 Tests the @on decorator pattern: Device B subscribes to Device A's events

--- a/tests/tests/test_d2d_rpc.py
+++ b/tests/tests/test_d2d_rpc.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for D2D (Device-to-Device) direct RPC invocation.
 
 Tests that one device can call another device's RPC directly,

--- a/tests/tests/test_d2o_events.py
+++ b/tests/tests/test_d2o_events.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for D2O event emission.
 
 Tests that device_connect_edge drivers emit events that can be captured

--- a/tests/tests/test_d2o_rpc.py
+++ b/tests/tests/test_d2o_rpc.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for D2O (Device-to-Orchestrator) RPC routing.
 
 Tests that MockOrchestrator can route events to device functions,

--- a/tests/tests/test_device_lifecycle.py
+++ b/tests/tests/test_device_lifecycle.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for device lifecycle.
 
 Tests that device_connect_edge-based drivers register with the real registry,

--- a/tests/tests/test_messaging_conformance.py
+++ b/tests/tests/test_messaging_conformance.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Messaging backend conformance tests.
 
 Validates that each MessagingClient implementation satisfies the ABC contract.

--- a/tests/tests/test_multi_device_scenario.py
+++ b/tests/tests/test_multi_device_scenario.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for multi-device scenarios.
 
 End-to-end tests with 3+ devices and orchestrator coordination.

--- a/tests/tests/test_sensor_device.py
+++ b/tests/tests/test_sensor_device.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for sensor device lifecycle.
 
 Tests that a TestSensorDriver registers, is discoverable, and can

--- a/tests/tests/test_strands_agent.py
+++ b/tests/tests/test_strands_agent.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for Strands Agent with device-connect-agent-tools.
 
 Tests that a Strands Agent can use Device Connect tools to discover and invoke devices.

--- a/tests/tests/test_tools_discover.py
+++ b/tests/tests/test_tools_discover.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for device-connect-agent-tools discover_devices().
 
 Tests that the agent SDK can discover devices registered via device_connect_edge.

--- a/tests/tests/test_tools_hierarchical.py
+++ b/tests/tests/test_tools_hierarchical.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for hierarchical discovery tools.
 
 Tests describe_fleet(), list_devices(), get_device_functions() and the

--- a/tests/tests/test_tools_invoke.py
+++ b/tests/tests/test_tools_invoke.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for device-connect-agent-tools invoke_device().
 
 Tests that the agent SDK can invoke device RPCs via the messaging backend.

--- a/tests/tests/test_zenoh_streaming.py
+++ b/tests/tests/test_zenoh_streaming.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Zenoh high-frequency streaming integration test.
 
 Validates that the ZenohAdapter can sustain 50Hz+ pub/sub throughput


### PR DESCRIPTION
## Summary
- Adds canonical SPDX short-form header + Arm copyright to all 208 qualifying source files (`.py`, `.sh`, `.yml`/`.yaml`, `.toml`) across `packages/device-connect-edge/`, `packages/device-connect-server/`, `packages/device-connect-agent-tools/`, `tests/`, and root configs. Prior baseline had zero headers.
- Header form matches Arm's ARM-software convention — copyright line first, blank, SPDX identifier second — with shebang scripts receiving the header immediately after the `#!` line.
- Documents the header requirement in `CONTRIBUTING.md` under the License section so future contributions stay uniform.

Motivation: Apache-2.0 §4.1 requires notice preservation on redistribution. Device Connect code is about to be consumed by downstream projects; this pass establishes a clean, machine-readable authorship trail before that happens.

Commits are split per package for easy review (edge, server, agent-tools, tests+root, CONTRIBUTING).

### Sample header
```
# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
#
# SPDX-License-Identifier: Apache-2.0
```

### Scope
| Group | .py | .sh | .yml | .toml |
|---|---|---|---|---|
| device-connect-edge | 57 | 0 | 0 | 1 |
| device-connect-server | 70 | 6 | 10 | 1 |
| device-connect-agent-tools | 32 | 0 | 0 | 1 |
| tests/ | 26 | 0 | 1 | 0 |
| root configs | 0 | 0 | 2 | 1 |

### Excluded (per scope)
`LICENSE`, `NOTICE`, `*.md`, `.gitignore`, `.editorconfig`, lock files, `__pycache__`, `*.egg-info`. No third-party copyrights were found in source; nothing to preserve or reconcile.

## Test plan
- [x] Python syntax check: `python3 -m py_compile` across all 185 `.py` files — exit 0
- [x] TOML parse: `tomllib` across 3 files — 0 errors
- [x] YAML parse: `yaml.safe_load_all` across 13 files — 0 errors
- [x] Bash syntax: `bash -n` across 6 `.sh` files — clean
- [ ] `ruff check` (run in CI — not available locally)
- [ ] Unit tests per package (run in CI — pytest not available locally; headers are pure comment blocks and cannot affect execution)