### PR TITLE
mcp: add wait_for_event tool + resource subscriptions to bridge

### DIFF
--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/bridge.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/bridge.py
@@ -34,6 +34,9 @@ from device_connect_edge.messaging import create_client
 from device_connect_edge.messaging.base import MessagingClient
 from device_connect_edge.registry_client import RegistryClient
 from device_connect_agent_tools.mcp.config import BridgeConfig
+from device_connect_agent_tools.mcp.event_subscriptions import (
+    EventSubscriptionManager, device_id_from_uri,
+)
 from device_connect_agent_tools.mcp.router import ToolRouter, ToolInvocationError
 from device_connect_agent_tools.tools import SMALL_FLEET_THRESHOLD
 from device_connect_agent_tools.connection import flatten_device
@@ -81,6 +84,7 @@ class MCPBridgeServer:
         self._registry = None  # RegistryClient or D2DRegistry (DiscoveryProvider)
         self._router: Optional[ToolRouter] = None
         self._d2d_collector = None  # PresenceCollector, if in D2D mode
+        self._event_subs: Optional[EventSubscriptionManager] = None
         self._running = False
 
     async def start(self) -> None:
@@ -104,11 +108,18 @@ class MCPBridgeServer:
                 timeout=self.config.request_timeout,
             )
 
-            # Create FastMCP server with 4 meta-tools
+            # Create FastMCP server with 4 meta-tools + event resource
             self._mcp = FastMCP("Device Connect Bridge")
             self._register_meta_tools()
 
-            logger.info("MCP Bridge ready — 4 meta-tools registered")
+            self._event_subs = EventSubscriptionManager(
+                self._messaging_client, self.config.tenant,
+            )
+            self._register_event_resource()
+            self._register_subscription_handlers()
+            self._enable_subscribe_capability()
+
+            logger.info("MCP Bridge ready — 4 meta-tools + events resource registered")
             await self._mcp.run_stdio_async()
 
         finally:
@@ -280,7 +291,12 @@ class MCPBridgeServer:
             description=(
                 "Call a function on a Device Connect device. "
                 "Use get_device_functions() first to see available functions "
-                "and their parameter schemas."
+                "and their parameter schemas. "
+                "If the function dispatches background work that will emit "
+                "events when it finishes, prefer waiting via wait_for_event "
+                "rather than re-invoking a status function in a poll loop — "
+                "wait_for_event blocks for the actual event with a single "
+                "tool call instead of burning many."
             ),
         )
         async def invoke_device(
@@ -294,6 +310,17 @@ class MCPBridgeServer:
             except json.JSONDecodeError as e:
                 return json.dumps({"success": False, "error": f"Invalid JSON arguments: {e}"})
 
+            # Pre-warm the event subscription for this device so any events
+            # the invocation triggers (progress / work_done / work_failed)
+            # land in the ring buffer for a subsequent wait_for_event call.
+            # Without this, fast tasks fire-and-finish before any waiter
+            # subscribes — exactly the dispatch→wait race.
+            if self._event_subs is not None:
+                try:
+                    await self._event_subs.ensure_fabric_sub(device_id)
+                except Exception:
+                    logger.debug("ensure_fabric_sub failed for %s", device_id, exc_info=True)
+
             tool_name = f"{device_id}::{function}"
             try:
                 result = await self._router.invoke(tool_name, args)
@@ -301,8 +328,106 @@ class MCPBridgeServer:
             except ToolInvocationError as e:
                 return json.dumps({"success": False, "error": str(e)})
 
+        @self._mcp.tool(
+            name="wait_for_event",
+            description=(
+                "Wait for an event from a Device Connect worker. Use this any "
+                "time the user asks to 'wait', 'tell me when', 'block until', "
+                "'let me know once', or otherwise expects you to know that a "
+                "background task finished — it's a single tool call instead "
+                "of a sleep+poll loop on the device's status function. "
+                "Race-safe: if the event already fired before this call (the "
+                "common case for fast tasks), it returns immediately from an "
+                "in-memory ring buffer. Otherwise blocks up to "
+                "timeout_seconds for a future event. Returns the event payload "
+                "({device_id, event_name, params}) or {\"timeout\": true} on no match. "
+                "TIP: for terminal events on a coding-worker, set "
+                "event_name='work_done' and run a parallel call with "
+                "event_name='work_failed' to catch either outcome — or omit "
+                "event_name and inspect event_name on the result. "
+                "Filter by task_id with match_params={\"task_id\": \"T-42\"} so "
+                "you don't pick up an unrelated task's event."
+            ),
+        )
+        async def wait_for_event(
+            device_id: str,
+            timeout_seconds: float = 60.0,
+            event_name: str = "",
+            match_params: str = "{}",
+        ) -> str:
+            try:
+                params = json.loads(match_params) if match_params else {}
+                if not isinstance(params, dict):
+                    raise ValueError("match_params must be a JSON object")
+            except (json.JSONDecodeError, ValueError) as exc:
+                return json.dumps({"error": f"invalid match_params: {exc}"})
+            if self._event_subs is None:
+                return json.dumps({"error": "event subscription manager not initialized"})
+            event = await self._event_subs.wait_for_event(
+                device_id=device_id,
+                timeout=max(0.0, float(timeout_seconds)),
+                event_name=event_name or "",
+                match_params=params or None,
+            )
+            if event is None:
+                return json.dumps({"timeout": True, "device_id": device_id})
+            return json.dumps(event, indent=2)
+
+    def _register_event_resource(self) -> None:
+        """Resource template returning the latest Device Connect event for a device."""
+        assert self._mcp is not None
+        assert self._event_subs is not None
+        event_subs = self._event_subs
+
+        @self._mcp.resource(
+            "events://devices/{device_id}/latest",
+            mime_type="application/json",
+            description=(
+                "Latest Device Connect event for the given device. Subscribe via "
+                "resources/subscribe to receive notifications/resources/updated when "
+                "the device emits a new event (progress, work_done, work_failed, ...)."
+            ),
+        )
+        async def latest_event(device_id: str) -> str:
+            return await event_subs.read(device_id)
+
+    def _register_subscription_handlers(self) -> None:
+        """Wire the low-level subscribe/unsubscribe MCP handlers."""
+        assert self._mcp is not None
+        assert self._event_subs is not None
+        low = self._mcp._mcp_server
+        event_subs = self._event_subs
+
+        @low.subscribe_resource()
+        async def _on_subscribe(uri):
+            await event_subs.subscribe(str(uri))
+
+        @low.unsubscribe_resource()
+        async def _on_unsubscribe(uri):
+            await event_subs.unsubscribe(str(uri))
+
+    def _enable_subscribe_capability(self) -> None:
+        """Advertise resources.subscribe=True; the MCP SDK hardcodes False otherwise."""
+        assert self._mcp is not None
+        low = self._mcp._mcp_server
+        original = low.get_capabilities
+
+        def patched(notification_options, experimental_capabilities):
+            caps = original(notification_options, experimental_capabilities)
+            if caps.resources is not None:
+                caps.resources.subscribe = True
+            return caps
+
+        low.get_capabilities = patched  # type: ignore[assignment]
+
     async def _cleanup(self) -> None:
         self._running = False
+        if self._event_subs:
+            try:
+                await self._event_subs.close()
+            except Exception as e:
+                logger.warning("Error closing event subscription manager: %s", e)
+            self._event_subs = None
         if self._d2d_collector:
             try:
                 await self._d2d_collector.stop()

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/bridge.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/bridge.py
@@ -34,9 +34,7 @@ from device_connect_edge.messaging import create_client
 from device_connect_edge.messaging.base import MessagingClient
 from device_connect_edge.registry_client import RegistryClient
 from device_connect_agent_tools.mcp.config import BridgeConfig
-from device_connect_agent_tools.mcp.event_subscriptions import (
-    EventSubscriptionManager, device_id_from_uri,
-)
+from device_connect_agent_tools.mcp.event_subscriptions import EventSubscriptionManager
 from device_connect_agent_tools.mcp.router import ToolRouter, ToolInvocationError
 from device_connect_agent_tools.tools import SMALL_FLEET_THRESHOLD
 from device_connect_agent_tools.connection import flatten_device

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/event_subscriptions.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/event_subscriptions.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bridge Device Connect events to MCP resource subscriptions.
+
+The MCP bridge exposes a resource template at
+``events://devices/{device_id}/latest``. Clients subscribe to that URI via
+``resources/subscribe``; whenever a Device Connect event arrives on
+``device-connect.{tenant}.{device_id}.event.>`` the manager pushes a
+``notifications/resources/updated`` to the subscribed session(s) and the
+client can re-read the resource to get the payload.
+
+This is the asynchronous push path — the MCP client does not need to call a
+blocking tool; the dispatcher LLM can keep doing other work and pick up the
+event between turns.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Optional
+
+from mcp.server.lowlevel.server import request_ctx
+from mcp.server.session import ServerSession
+from pydantic import AnyUrl
+
+logger = logging.getLogger(__name__)
+
+_URI_PREFIX = "events://devices/"
+_URI_SUFFIX = "/latest"
+
+
+def device_id_from_uri(uri: str) -> Optional[str]:
+    """Extract device_id from ``events://devices/{device_id}/latest``.
+
+    Returns None if *uri* does not match the expected shape. We parse by
+    string ops rather than urllib to keep the URI scheme custom-friendly.
+    """
+    if not uri.startswith(_URI_PREFIX) or not uri.endswith(_URI_SUFFIX):
+        return None
+    middle = uri[len(_URI_PREFIX): -len(_URI_SUFFIX)]
+    if not middle or "/" in middle:
+        return None
+    return middle
+
+
+def uri_for_device(device_id: str) -> str:
+    return f"{_URI_PREFIX}{device_id}{_URI_SUFFIX}"
+
+
+def _parse_event(subject: str, data: bytes) -> tuple[str, dict[str, Any]]:
+    """Pull (event_name, params) out of a Device Connect event message.
+
+    Zenoh delivers the matched key using '/' as the separator; NATS uses '.'.
+    We normalize before splitting so both backends work.
+    """
+    parts = subject.replace("/", ".").split(".")
+    # Expected: device-connect.{tenant}.{device}.event.{event_name}
+    event_name = parts[-1] if len(parts) >= 5 else "unknown"
+    try:
+        payload = json.loads(data.decode())
+    except Exception:
+        return event_name, {"raw": data.decode("utf-8", errors="replace")[:500]}
+
+    if isinstance(payload, dict) and "method" in payload:
+        # JSON-RPC notification envelope: pull the params out
+        params = payload.get("params", {})
+        if not isinstance(params, dict):
+            params = {"value": params}
+        return event_name, params
+    if isinstance(payload, dict):
+        return event_name, payload
+    return event_name, {"value": payload}
+
+
+# How many recent events to keep per device. Sized for the dispatch→wait race
+# window — the worker can fire a handful of progress events plus a terminal
+# event between dispatch returning and a wait_for_event call subscribing.
+_RECENT_EVENTS_LIMIT = 32
+
+
+def _matches(event: dict[str, Any], event_name: str, match_params: Optional[dict[str, Any]]) -> bool:
+    """Return True iff *event* satisfies the optional name + params filters."""
+    if event_name and event.get("event_name") != event_name:
+        return False
+    if match_params:
+        p = event.get("params") or {}
+        if not all(p.get(k) == v for k, v in match_params.items()):
+            return False
+    return True
+
+
+class EventSubscriptionManager:
+    """Tracks MCP subscriptions and forwards Device Connect events to subscribers."""
+
+    def __init__(self, messaging_client: Any, tenant: str) -> None:
+        self._messaging = messaging_client
+        self._tenant = tenant
+        self._device_subs: dict[str, Any] = {}
+        # device_id -> set of (session, uri_string) pairs
+        self._subscribers: dict[str, set[tuple[ServerSession, str]]] = {}
+        self._latest: dict[str, dict[str, Any]] = {}
+        # device_id -> ring of recent events (oldest first), so wait_for_event
+        # can resolve dispatch→wait races against events that already fired.
+        self._recent: dict[str, list[dict[str, Any]]] = {}
+        self._lock = asyncio.Lock()
+        # device_id -> list of asyncio.Queue feeding waiters (one queue per waiter)
+        self._waiters: dict[str, list[asyncio.Queue]] = {}
+        # device_ids whose fabric subscription is pinned (won't be torn down by
+        # waiter timeouts or unsubscribes). Used to pre-warm subs on
+        # invoke_device so wait_for_event catches events that fire faster than
+        # the round-trip from the dispatcher.
+        self._pinned: set[str] = set()
+
+    async def subscribe(self, uri: str) -> None:
+        """Handle an MCP ``resources/subscribe`` request."""
+        device_id = device_id_from_uri(uri)
+        if device_id is None:
+            logger.warning("subscribe: unrecognized URI %s", uri)
+            return
+        try:
+            session: ServerSession = request_ctx.get().session
+        except LookupError:
+            logger.error("subscribe: no active request context for %s", uri)
+            return
+
+        async with self._lock:
+            self._subscribers.setdefault(device_id, set()).add((session, uri))
+            if device_id not in self._device_subs:
+                self._device_subs[device_id] = await self._start_fabric_sub(device_id)
+        logger.info("MCP subscribe: device=%s session=%s", device_id, id(session))
+
+    async def unsubscribe(self, uri: str) -> None:
+        """Handle an MCP ``resources/unsubscribe`` request."""
+        device_id = device_id_from_uri(uri)
+        if device_id is None:
+            return
+        try:
+            session: ServerSession = request_ctx.get().session
+        except LookupError:
+            return
+
+        fabric_sub = None
+        async with self._lock:
+            subs = self._subscribers.get(device_id)
+            if subs is None:
+                return
+            subs.discard((session, uri))
+            if subs:
+                return
+            self._subscribers.pop(device_id, None)
+            # Don't tear down the fabric sub if it's pinned (pre-warmed by
+            # invoke_device) or if a wait_for_event is still listening.
+            if device_id not in self._pinned and not self._waiters.get(device_id):
+                fabric_sub = self._device_subs.pop(device_id, None)
+        if fabric_sub is not None:
+            try:
+                await fabric_sub.unsubscribe()
+            except Exception:
+                logger.debug("error unsubscribing fabric sub", exc_info=True)
+        logger.info("MCP unsubscribe: device=%s session=%s", device_id, id(session))
+
+    async def read(self, device_id: str) -> str:
+        """Return the latest event for *device_id* as a JSON string."""
+        payload = self._latest.get(device_id)
+        if payload is None:
+            return json.dumps({"device_id": device_id, "event_name": None, "params": {}})
+        return json.dumps(payload)
+
+    async def ensure_fabric_sub(self, device_id: str) -> None:
+        """Pre-warm a fabric subscription for *device_id* and pin it.
+
+        Called by the bridge before any invoke_device so events fired
+        between the RPC reply and a subsequent wait_for_event are
+        captured in the ring buffer rather than lost. Pinned subs
+        survive waiter/unsubscribe teardown and are released only when
+        the bridge shuts down (close()).
+        """
+        async with self._lock:
+            self._pinned.add(device_id)
+            if device_id not in self._device_subs:
+                self._device_subs[device_id] = await self._start_fabric_sub(device_id)
+
+    async def wait_for_event(
+        self,
+        device_id: str,
+        timeout: float,
+        event_name: str = "",
+        match_params: Optional[dict[str, Any]] = None,
+    ) -> Optional[dict[str, Any]]:
+        """Wait for a matching event for *device_id*, or return None on timeout.
+
+        Resolves the classic dispatch→wait race by checking the recent-event
+        ring buffer first. If a matching event already fired (e.g. the task
+        completed before the caller subscribed), it's returned immediately.
+        Otherwise, blocks for the next matching event until *timeout*.
+
+        Args:
+            device_id: Which device to listen on.
+            timeout: Seconds to wait for a future event. Past matches in the
+                ring buffer return immediately regardless.
+            event_name: Optional event-name filter (e.g. "work_done"). Empty
+                string matches any event.
+            match_params: Optional ``{key: value}`` constraints; the event's
+                params must contain every key with the same value to match.
+                Useful for filtering by ``task_id``.
+
+        Returns:
+            The matched event dict (``{device_id, event_name, params}``) or
+            None on timeout.
+        """
+        # Race fix: scan recent events first (newest → oldest). Handles the
+        # case where the worker fires the terminal event before the caller
+        # gets to subscribe.
+        async with self._lock:
+            recent = list(self._recent.get(device_id, []))
+        for event in reversed(recent):
+            if _matches(event, event_name, match_params):
+                return event
+
+        # Ensure a fabric subscription exists for this device while we wait.
+        async with self._lock:
+            if device_id not in self._device_subs:
+                self._device_subs[device_id] = await self._start_fabric_sub(device_id)
+            queue: asyncio.Queue = asyncio.Queue()
+            self._waiters.setdefault(device_id, []).append(queue)
+        try:
+            deadline = asyncio.get_event_loop().time() + timeout
+            while True:
+                remaining = deadline - asyncio.get_event_loop().time()
+                if remaining <= 0:
+                    return None
+                try:
+                    payload = await asyncio.wait_for(queue.get(), timeout=remaining)
+                except asyncio.TimeoutError:
+                    return None
+                if not _matches(payload, event_name, match_params):
+                    continue
+                return payload
+        finally:
+            sub_to_release = None
+            async with self._lock:
+                waiters = self._waiters.get(device_id, [])
+                if queue in waiters:
+                    waiters.remove(queue)
+                if not waiters:
+                    self._waiters.pop(device_id, None)
+                    # Tear down the fabric sub only if no MCP subscriber and not pinned.
+                    if (
+                        device_id not in self._subscribers
+                        and device_id not in self._pinned
+                    ):
+                        sub_to_release = self._device_subs.pop(device_id, None)
+            if sub_to_release is not None:
+                try:
+                    await sub_to_release.unsubscribe()
+                except Exception:
+                    logger.debug("error releasing fabric sub", exc_info=True)
+
+    async def close(self) -> None:
+        """Tear down all fabric subscriptions and clear in-memory state."""
+        async with self._lock:
+            subs = list(self._device_subs.values())
+            self._device_subs.clear()
+            self._subscribers.clear()
+            self._pinned.clear()
+            self._waiters.clear()
+        for sub in subs:
+            try:
+                await sub.unsubscribe()
+            except Exception:
+                logger.debug("error unsubscribing during close", exc_info=True)
+
+    # ── fabric-side ────────────────────────────────────────────────────
+
+    async def _start_fabric_sub(self, device_id: str) -> Any:
+        subject = f"device-connect.{self._tenant}.{device_id}.event.>"
+
+        async def on_msg(data: bytes, msg_subject: str, reply: str = "") -> None:
+            await self._handle_event(device_id, msg_subject, data)
+
+        sub = await self._messaging.subscribe_with_subject(subject, callback=on_msg)
+        logger.info("event-bridge subscribed to fabric subject: %s", subject)
+        return sub
+
+    async def _handle_event(self, device_id: str, subject: str, data: bytes) -> None:
+        event_name, params = _parse_event(subject, data)
+        payload = {"device_id": device_id, "event_name": event_name, "params": params}
+        self._latest[device_id] = payload
+
+        async with self._lock:
+            ring = self._recent.setdefault(device_id, [])
+            ring.append(payload)
+            if len(ring) > _RECENT_EVENTS_LIMIT:
+                del ring[: len(ring) - _RECENT_EVENTS_LIMIT]
+            subs = list(self._subscribers.get(device_id, set()))
+            waiters = list(self._waiters.get(device_id, []))
+        for session, uri in subs:
+            try:
+                await session.send_resource_updated(AnyUrl(uri))
+            except Exception:
+                logger.warning(
+                    "failed to push resources/updated for %s to session=%s",
+                    uri, id(session), exc_info=True,
+                )
+        for queue in waiters:
+            try:
+                queue.put_nowait(payload)
+            except Exception:
+                logger.debug("waiter queue put failed", exc_info=True)

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/event_subscriptions.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/event_subscriptions.py
@@ -21,11 +21,26 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
-from mcp.server.lowlevel.server import request_ctx
-from mcp.server.session import ServerSession
 from pydantic import AnyUrl
+
+# Mirrors bridge.py's fastmcp guard. The fuzz CI job installs [dev,fuzz] but
+# not [mcp], so mcp must be importable lazily — top-level imports of
+# `mcp.server.*` here would break collection of any test that touches
+# device_connect_agent_tools.mcp.* (because mcp/__init__.py eagerly imports
+# bridge, which imports this module). EventSubscriptionManager is only
+# instantiated by the bridge after its own fastmcp guard passes, so a runtime
+# AttributeError on request_ctx is a real bug — we re-raise it loudly.
+try:
+    from mcp.server.lowlevel.server import request_ctx
+    _MCP_AVAILABLE = True
+except ImportError:  # pragma: no cover - fuzz/lint envs without [mcp]
+    _MCP_AVAILABLE = False
+    request_ctx = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:
+    from mcp.server.session import ServerSession
 
 logger = logging.getLogger(__name__)
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/event_subscriptions.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/event_subscriptions.py
@@ -227,17 +227,15 @@ class EventSubscriptionManager:
             The matched event dict (``{device_id, event_name, params}``) or
             None on timeout.
         """
-        # Race fix: scan recent events first (newest → oldest). Handles the
-        # case where the worker fires the terminal event before the caller
-        # gets to subscribe.
+        # Race fix: scan recent events and register the waiter under a
+        # single lock acquisition. _handle_event holds the same lock when
+        # it appends to the ring and reads the waiter list, so any event
+        # arriving concurrently is either visible in this scan or will
+        # wake the waiter we register below — never lost between them.
         async with self._lock:
-            recent = list(self._recent.get(device_id, []))
-        for event in reversed(recent):
-            if _matches(event, event_name, match_params):
-                return event
-
-        # Ensure a fabric subscription exists for this device while we wait.
-        async with self._lock:
+            for event in reversed(self._recent.get(device_id, [])):
+                if _matches(event, event_name, match_params):
+                    return event
             if device_id not in self._device_subs:
                 self._device_subs[device_id] = await self._start_fabric_sub(device_id)
             queue: asyncio.Queue = asyncio.Queue()

--- a/packages/device-connect-agent-tools/tests/test_mcp_bridge_subscriptions.py
+++ b/packages/device-connect-agent-tools/tests/test_mcp_bridge_subscriptions.py
@@ -1,0 +1,474 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the MCP bridge's event subscription manager.
+
+These tests exercise EventSubscriptionManager in isolation — a fake messaging
+client captures the subscribe callback so the test can fire synthetic events,
+and a fake ServerSession records send_resource_updated calls so we can assert
+the right URIs were notified. No actual MCP transport, no Device Connect
+fabric, no FastMCP server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Callable
+
+import pytest
+
+from device_connect_agent_tools.mcp import event_subscriptions as es
+
+
+# ── Fakes ──────────────────────────────────────────────────────────────
+
+
+class _FakeFabricSub:
+    """Stand-in for the subscription handle returned by MessagingClient."""
+
+    def __init__(self) -> None:
+        self.unsubscribed = False
+
+    async def unsubscribe(self) -> None:
+        self.unsubscribed = True
+
+
+@dataclass
+class _FakeMessagingClient:
+    """Captures the (subject, callback) pairs the manager registers."""
+
+    subs: dict[str, tuple[Callable, _FakeFabricSub]] = field(default_factory=dict)
+
+    async def subscribe_with_subject(self, subject: str, callback: Callable) -> _FakeFabricSub:
+        sub = _FakeFabricSub()
+        self.subs[subject] = (callback, sub)
+        return sub
+
+    async def fire(self, subject: str, payload: dict | bytes) -> None:
+        """Find a registered (possibly-wildcarded) subject that matches and invoke it."""
+        cb = None
+        for registered, (callback, _sub) in self.subs.items():
+            if registered.endswith(".>"):
+                if subject.startswith(registered[:-2] + "."):
+                    cb = callback
+                    break
+            elif registered == subject:
+                cb = callback
+                break
+        if cb is None:
+            return  # no subscriber — fire-and-forget like a real broker
+        data = payload if isinstance(payload, bytes) else json.dumps(payload).encode()
+        await cb(data, subject, "")
+
+
+class _FakeSession:
+    """Records send_resource_updated calls; mimics ServerSession surface."""
+
+    def __init__(self) -> None:
+        self.updated: list[str] = []
+
+    async def send_resource_updated(self, uri) -> None:
+        self.updated.append(str(uri))
+
+
+@contextlib.contextmanager
+def _request_ctx_with_session(session: _FakeSession):
+    """Push a fake request context so manager.subscribe() can grab the session."""
+    token = es.request_ctx.set(SimpleNamespace(session=session))
+    try:
+        yield
+    finally:
+        es.request_ctx.reset(token)
+
+
+# ── URI helpers ───────────────────────────────────────────────────────
+
+
+def test_uri_round_trip() -> None:
+    assert es.uri_for_device("pi-desk") == "events://devices/pi-desk/latest"
+    assert es.device_id_from_uri("events://devices/pi-desk/latest") == "pi-desk"
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "events://devices//latest",          # empty device id
+        "events://devices/pi/desk/latest",   # nested path → not a single id
+        "events://devices/pi-desk",          # missing /latest suffix
+        "http://example.com/foo",            # wrong scheme
+        "",
+    ],
+)
+def test_device_id_from_uri_rejects_garbage(uri: str) -> None:
+    assert es.device_id_from_uri(uri) is None
+
+
+# ── Event parsing ─────────────────────────────────────────────────────
+
+
+def test_parse_event_with_jsonrpc_envelope() -> None:
+    subject = "device-connect.alice.pi-desk.event.work_done"
+    data = json.dumps({
+        "jsonrpc": "2.0",
+        "method": "work_done",
+        "params": {"task_id": "T-42", "branch": "feature/T-42"},
+    }).encode()
+    name, params = es._parse_event(subject, data)
+    assert name == "work_done"
+    assert params == {"task_id": "T-42", "branch": "feature/T-42"}
+
+
+def test_parse_event_with_bare_dict() -> None:
+    name, params = es._parse_event(
+        "device-connect.alice.pi-desk.event.progress",
+        json.dumps({"step": "push"}).encode(),
+    )
+    assert name == "progress"
+    assert params == {"step": "push"}
+
+
+def test_parse_event_with_zenoh_style_separator() -> None:
+    """Zenoh delivers matched keys with '/' separators; NATS uses '.'. Both must parse."""
+    name, params = es._parse_event(
+        "device-connect/alice/pi-desk/event/work_done",
+        json.dumps({"task_id": "T-42", "branch": "feature/T-42"}).encode(),
+    )
+    assert name == "work_done"
+    assert params == {"task_id": "T-42", "branch": "feature/T-42"}
+
+
+def test_parse_event_with_garbage_bytes() -> None:
+    name, params = es._parse_event(
+        "device-connect.alice.pi-desk.event.weird",
+        b"\x00\x01not-json",
+    )
+    assert name == "weird"
+    assert "raw" in params
+
+
+# ── Manager behavior ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_subscribe_then_event_notifies_session() -> None:
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+    session = _FakeSession()
+    uri = es.uri_for_device("pi-desk")
+
+    with _request_ctx_with_session(session):
+        await mgr.subscribe(uri)
+
+    # One fabric subscription was created with the right subject pattern.
+    assert "device-connect.alice.pi-desk.event.>" in msg.subs
+
+    await msg.fire(
+        "device-connect.alice.pi-desk.event.work_done",
+        {"jsonrpc": "2.0", "method": "work_done",
+         "params": {"task_id": "T-42", "branch": "feature/T-42"}},
+    )
+    # Give the callback a tick to run if it scheduled anything.
+    await asyncio.sleep(0)
+
+    assert session.updated == [uri]
+    # And the latest event is now readable.
+    payload = json.loads(await mgr.read("pi-desk"))
+    assert payload["device_id"] == "pi-desk"
+    assert payload["event_name"] == "work_done"
+    assert payload["params"]["task_id"] == "T-42"
+
+
+@pytest.mark.asyncio
+async def test_two_sessions_one_device_share_a_fabric_sub() -> None:
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+    s1, s2 = _FakeSession(), _FakeSession()
+    uri = es.uri_for_device("pi-desk")
+
+    with _request_ctx_with_session(s1):
+        await mgr.subscribe(uri)
+    with _request_ctx_with_session(s2):
+        await mgr.subscribe(uri)
+
+    # Still only one fabric subscription.
+    assert len(msg.subs) == 1
+
+    await msg.fire(
+        "device-connect.alice.pi-desk.event.progress",
+        {"step": "agent"},
+    )
+    await asyncio.sleep(0)
+
+    assert s1.updated == [uri]
+    assert s2.updated == [uri]
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_releases_fabric_sub_when_last_subscriber_leaves() -> None:
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+    s1, s2 = _FakeSession(), _FakeSession()
+    uri = es.uri_for_device("pi-desk")
+
+    with _request_ctx_with_session(s1):
+        await mgr.subscribe(uri)
+    with _request_ctx_with_session(s2):
+        await mgr.subscribe(uri)
+
+    fabric = msg.subs["device-connect.alice.pi-desk.event.>"][1]
+
+    # First unsubscribe: fabric sub stays alive.
+    with _request_ctx_with_session(s1):
+        await mgr.unsubscribe(uri)
+    assert not fabric.unsubscribed
+
+    # Second unsubscribe: fabric sub is torn down.
+    with _request_ctx_with_session(s2):
+        await mgr.unsubscribe(uri)
+    assert fabric.unsubscribed
+
+    # Subsequent events reach no one.
+    await msg.fire(
+        "device-connect.alice.pi-desk.event.work_done",
+        {"step": "push"},
+    )
+    await asyncio.sleep(0)
+    assert s1.updated == []
+    assert s2.updated == []
+
+
+@pytest.mark.asyncio
+async def test_read_returns_empty_payload_when_no_events_yet() -> None:
+    mgr = es.EventSubscriptionManager(_FakeMessagingClient(), tenant="alice")
+    payload = json.loads(await mgr.read("pi-desk"))
+    assert payload == {"device_id": "pi-desk", "event_name": None, "params": {}}
+
+
+@pytest.mark.asyncio
+async def test_subscribe_to_unrelated_uri_is_a_noop() -> None:
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+    session = _FakeSession()
+
+    with _request_ctx_with_session(session):
+        await mgr.subscribe("file:///something/else")
+
+    assert msg.subs == {}
+    assert session.updated == []
+
+
+# ── wait_for_event ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wait_for_event_returns_matching_event() -> None:
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+
+    waiter = asyncio.create_task(mgr.wait_for_event("pi-desk", timeout=5.0))
+    # Yield to let waiter register
+    await asyncio.sleep(0)
+
+    await msg.fire(
+        "device-connect.alice.pi-desk.event.work_done",
+        {"jsonrpc": "2.0", "method": "work_done",
+         "params": {"task_id": "T-42", "branch": "feature/T-42"}},
+    )
+    result = await asyncio.wait_for(waiter, timeout=2.0)
+
+    assert result is not None
+    assert result["event_name"] == "work_done"
+    assert result["params"]["task_id"] == "T-42"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_event_filters_by_event_name() -> None:
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+
+    waiter = asyncio.create_task(
+        mgr.wait_for_event("pi-desk", timeout=5.0, event_name="work_done"),
+    )
+    await asyncio.sleep(0)
+
+    # Progress event should be skipped, work_done should resolve.
+    await msg.fire(
+        "device-connect.alice.pi-desk.event.progress",
+        {"jsonrpc": "2.0", "method": "progress", "params": {"step": "agent"}},
+    )
+    await msg.fire(
+        "device-connect.alice.pi-desk.event.work_done",
+        {"jsonrpc": "2.0", "method": "work_done", "params": {"task_id": "T-42"}},
+    )
+
+    result = await asyncio.wait_for(waiter, timeout=2.0)
+    assert result["event_name"] == "work_done"
+    assert result["params"]["task_id"] == "T-42"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_event_filters_by_match_params() -> None:
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+
+    waiter = asyncio.create_task(
+        mgr.wait_for_event(
+            "pi-desk",
+            timeout=5.0,
+            event_name="work_done",
+            match_params={"task_id": "T-target"},
+        ),
+    )
+    await asyncio.sleep(0)
+
+    # Non-matching task_id is ignored
+    await msg.fire(
+        "device-connect.alice.pi-desk.event.work_done",
+        {"jsonrpc": "2.0", "method": "work_done", "params": {"task_id": "T-other"}},
+    )
+    # Matching task_id resolves the waiter
+    await msg.fire(
+        "device-connect.alice.pi-desk.event.work_done",
+        {"jsonrpc": "2.0", "method": "work_done", "params": {"task_id": "T-target"}},
+    )
+
+    result = await asyncio.wait_for(waiter, timeout=2.0)
+    assert result["params"]["task_id"] == "T-target"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_event_returns_none_on_timeout() -> None:
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+
+    result = await mgr.wait_for_event("pi-desk", timeout=0.05)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_wait_for_event_resolves_dispatch_to_wait_race() -> None:
+    """Event already fired before wait_for_event is called → ring buffer hit."""
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+
+    # Pre-warm the fabric subscription so events flow into the ring.
+    s = _FakeSession()
+    with _request_ctx_with_session(s):
+        await mgr.subscribe(es.uri_for_device("pi-desk"))
+
+    # Worker fires work_done BEFORE the wait call.
+    await msg.fire(
+        "device-connect.alice.pi-desk.event.work_done",
+        {"jsonrpc": "2.0", "method": "work_done",
+         "params": {"task_id": "T-fast", "branch": "feature/T-fast"}},
+    )
+    await asyncio.sleep(0)  # let _handle_event run
+
+    # Now wait — should return immediately from the ring buffer, not block.
+    result = await mgr.wait_for_event(
+        "pi-desk", timeout=0.05,
+        event_name="work_done", match_params={"task_id": "T-fast"},
+    )
+    assert result is not None
+    assert result["params"]["task_id"] == "T-fast"
+
+
+@pytest.mark.asyncio
+async def test_ensure_fabric_sub_pre_warms_and_pins() -> None:
+    """ensure_fabric_sub creates the sub and survives waiter timeouts."""
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+
+    await mgr.ensure_fabric_sub("pi-desk")
+    assert "device-connect.alice.pi-desk.event.>" in msg.subs
+
+    # An event fired before any waiter subscribes still lands in the ring.
+    await msg.fire(
+        "device-connect.alice.pi-desk.event.work_done",
+        {"jsonrpc": "2.0", "method": "work_done", "params": {"task_id": "T-pre"}},
+    )
+    await asyncio.sleep(0)
+
+    # Wait now finds it from the ring.
+    result = await mgr.wait_for_event(
+        "pi-desk", timeout=0.05,
+        event_name="work_done", match_params={"task_id": "T-pre"},
+    )
+    assert result is not None
+    assert result["params"]["task_id"] == "T-pre"
+
+    # Waiter timeout should NOT release the pinned fabric sub.
+    await mgr.wait_for_event("pi-desk", timeout=0.01,
+                             event_name="future_event_that_never_fires")
+    fabric = msg.subs["device-connect.alice.pi-desk.event.>"][1]
+    assert not fabric.unsubscribed
+
+    # close() releases everything.
+    await mgr.close()
+    assert fabric.unsubscribed
+
+
+@pytest.mark.asyncio
+async def test_wait_for_event_ring_buffer_skips_non_matching() -> None:
+    """Newer non-matching event in the ring shouldn't mask an older match."""
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+    s = _FakeSession()
+    with _request_ctx_with_session(s):
+        await mgr.subscribe(es.uri_for_device("pi-desk"))
+
+    # Two events: a target work_done first, then an unrelated progress.
+    await msg.fire(
+        "device-connect.alice.pi-desk.event.work_done",
+        {"jsonrpc": "2.0", "method": "work_done", "params": {"task_id": "T-a"}},
+    )
+    await msg.fire(
+        "device-connect.alice.pi-desk.event.progress",
+        {"jsonrpc": "2.0", "method": "progress", "params": {"step": "agent"}},
+    )
+    await asyncio.sleep(0)
+
+    result = await mgr.wait_for_event(
+        "pi-desk", timeout=0.05,
+        event_name="work_done", match_params={"task_id": "T-a"},
+    )
+    assert result is not None
+    assert result["event_name"] == "work_done"
+    assert result["params"]["task_id"] == "T-a"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_event_releases_fabric_sub_when_no_other_listeners() -> None:
+    """A timed-out waiter shouldn't leave a dangling fabric subscription."""
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+
+    await mgr.wait_for_event("pi-desk", timeout=0.05)
+    # Fabric sub was created during the wait. After it times out and no
+    # other listener exists, the manager calls .unsubscribe() on it.
+    sub_entry = msg.subs.get("device-connect.alice.pi-desk.event.>")
+    assert sub_entry is not None, "fabric sub should have been created"
+    _cb, fabric = sub_entry
+    assert fabric.unsubscribed
+
+
+@pytest.mark.asyncio
+async def test_wait_for_event_keeps_fabric_sub_when_session_still_subscribed() -> None:
+    """A waiter that exits shouldn't tear down fabric subs an MCP session is using."""
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+    session = _FakeSession()
+    uri = es.uri_for_device("pi-desk")
+
+    with _request_ctx_with_session(session):
+        await mgr.subscribe(uri)
+    fabric = msg.subs["device-connect.alice.pi-desk.event.>"][1]
+
+    await mgr.wait_for_event("pi-desk", timeout=0.05)  # times out
+
+    assert not fabric.unsubscribed  # session still holding it

--- a/packages/device-connect-agent-tools/tests/test_mcp_bridge_subscriptions.py
+++ b/packages/device-connect-agent-tools/tests/test_mcp_bridge_subscriptions.py
@@ -472,3 +472,56 @@ async def test_wait_for_event_keeps_fabric_sub_when_session_still_subscribed() -
     await mgr.wait_for_event("pi-desk", timeout=0.05)  # times out
 
     assert not fabric.unsubscribed  # session still holding it
+
+
+@pytest.mark.asyncio
+async def test_wait_for_event_scans_and_registers_under_one_lock() -> None:
+    """Regression: scan + register must happen under a single lock
+    acquisition.
+
+    Earlier wait_for_event took the manager lock twice — once to snapshot
+    the ring, again to register the waiter. _handle_event holds the same
+    lock when it appends to the ring and reads the waiter list, so an
+    event arriving between those two acquisitions would land in the ring
+    with zero waiters listening, and the just-registered waiter would
+    block until timeout despite the matching event being right there.
+
+    Hard to exercise behaviorally in single-task asyncio (no await
+    between the two blocks unless the lock is contended), so we assert
+    the structural invariant directly: the no-match path acquires the
+    lock exactly twice (once for atomic scan+register, once for
+    teardown). Pre-fix this would have been three.
+    """
+    msg = _FakeMessagingClient()
+    mgr = es.EventSubscriptionManager(msg, tenant="alice")
+
+    real_lock = mgr._lock
+    n_acquires = 0
+
+    class _CountingLock:
+        async def acquire(self) -> bool:
+            nonlocal n_acquires
+            n_acquires += 1
+            return await real_lock.acquire()
+
+        def release(self) -> None:
+            real_lock.release()
+
+        def locked(self) -> bool:
+            return real_lock.locked()
+
+        async def __aenter__(self) -> "_CountingLock":
+            await self.acquire()
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            self.release()
+
+    mgr._lock = _CountingLock()  # type: ignore[assignment]
+
+    result = await mgr.wait_for_event("pi-desk", timeout=0.01)
+    assert result is None
+    assert n_acquires == 2, (
+        f"expected 2 lock acquisitions (atomic scan+register, then teardown); "
+        f"got {n_acquires} — scan and register may have split the lock again"
+    )

--- a/tests/tests/test_sensor_device.py
+++ b/tests/tests/test_sensor_device.py
@@ -151,18 +151,32 @@ async def test_sensor_capabilities(device_spawner, messaging_url):
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_multiple_sensors(device_spawner, messaging_url):
-    """Multiple sensors should coexist."""
+    """Multiple sensors should coexist.
+
+    Replaces the previous single fixed-sleep settle with a poll-until-both-
+    visible loop. SETTLE_TIME=0.5s is too tight for Zenoh D2D peer
+    convergence under CI load — both peers' presence announcements need to
+    propagate before discover_devices() sees them, and which one arrives
+    first is non-deterministic.
+    """
     _, _ = await device_spawner.spawn_sensor("itest-sensor-a")
     _, _ = await device_spawner.spawn_sensor("itest-sensor-b")
     await asyncio.sleep(SETTLE_TIME)
 
     from device_connect_agent_tools import connect, disconnect, discover_devices
 
+    expected = {"itest-sensor-a", "itest-sensor-b"}
     await asyncio.to_thread(connect, nats_url=messaging_url)
     try:
-        devices = await asyncio.to_thread(discover_devices)
-        ids = [d["device_id"] for d in devices]
-        assert "itest-sensor-a" in ids
-        assert "itest-sensor-b" in ids
+        deadline = asyncio.get_event_loop().time() + 10.0
+        ids: set[str] = set()
+        while asyncio.get_event_loop().time() < deadline:
+            devices = await asyncio.to_thread(discover_devices, refresh=True)
+            ids = {d["device_id"] for d in devices}
+            if expected <= ids:
+                break
+            await asyncio.sleep(0.5)
+        assert "itest-sensor-a" in ids, f"sensor-a not in {ids}"
+        assert "itest-sensor-b" in ids, f"sensor-b not in {ids}"
     finally:
         await asyncio.to_thread(disconnect)


### PR DESCRIPTION
## Summary

Two new event-delivery surfaces on the `device-connect-agent-tools` MCP
bridge, both backed by the same `EventSubscriptionManager`. Either lets a
dispatcher agent learn when a remote device emits an event
(`progress` / `work_done` / `work_failed` / …) without polling a status
function in a loop.

### `wait_for_event` tool

- One-call wait for a Device Connect event. Filter by `event_name`
  (e.g. `work_done`) and/or `match_params` (e.g. `{"task_id": "T-42"}`).
  Returns the matched event payload or `{"timeout": true}`.
- **Race-safe**: a 32-event-per-device ring buffer holds recent events.
  If the matching event already fired before the wait call lands (the
  common dispatch→wait race for fast tasks), the tool returns
  immediately from the buffer. Otherwise blocks up to `timeout_seconds`
  for a future event.
- **Pre-warm**: every `invoke_device` call ensures a fabric subscription
  exists for the target device before the RPC reply, so events fired
  during the invocation always land in the ring buffer for a subsequent
  wait. Pinned subs survive waiter timeouts and resource unsubscribes —
  released only on bridge shutdown.

### Resource subscriptions

- New resource template `events://devices/{device_id}/latest` exposes
  the most recent event payload for a given device.
- Bridge handles `resources/subscribe` and pushes
  `notifications/resources/updated` to subscribed sessions when events
  arrive. Refcounted: one fabric subscription per device, shared across
  multiple session subscribers.
- `get_capabilities` patched to advertise `resources.subscribe=true`
  (the underlying MCP SDK hardcodes `False`; FastMCP doesn't expose a
  clean override path).

### Tool description tightening

- `invoke_device`: nudges agents to prefer `wait_for_event` over
  re-invoking a status function in a poll loop.
- `wait_for_event`: spells out everyday triggers (\"wait\", \"tell me
  when\", \"block until\"), explains race-safety, and includes a TIP
  for waiting on terminal events.

`EventSubscriptionManager` (`mcp/event_subscriptions.py`) is the
underlying implementation — encapsulates the ring buffer, waiter
queues, fabric subscription lifecycle, and resource-subscribe state.
Reusable for clients that want the push surface without going through
the bridge.

### Why both surfaces

CLI MCP clients (codex CLI, Claude Code) don't actively use
`resources/subscribe` today — they call tools. `wait_for_event` covers
that case with a single tool call. The resource subscription path is
useful for MCP clients that do subscribe natively (Claude Desktop) and
is future-proofing for CLI clients as their support catches up. Both
surfaces share the same fabric subscription and ring buffer, so adding
the second surface costs nothing on the wire.

## Test plan

24 unit tests in `tests/test_mcp_bridge_subscriptions.py` cover:

- [x] URI parse/build (`uri_for_device`, `device_id_from_uri`) including 5 garbage-input rejections
- [x] Event payload parsing — JSON-RPC envelope, bare dict, malformed bytes
- [x] Subject-name extraction from both NATS-style (`.`) and Zenoh-style (`/`) separators
- [x] Subscribe → fire event → session notified, latest cached
- [x] Two sessions sharing one fabric subscription
- [x] Refcounted unsubscribe tears down fabric sub when last subscriber leaves
- [x] Subscribe to unrelated URI is a no-op
- [x] `wait_for_event` returns matching event
- [x] `wait_for_event` filters by `event_name`
- [x] `wait_for_event` filters by `match_params`
- [x] `wait_for_event` returns `None` on timeout
- [x] `wait_for_event` releases fabric sub on lone-waiter timeout
- [x] `wait_for_event` keeps fabric sub when a session subscription still holds it
- [x] `ensure_fabric_sub` pins the sub; survives waiter timeout; released on `close()`
- [x] **Race fix**: event already fired before `wait_for_event` is called → ring-buffer hit returns immediately
- [x] Ring-buffer scan skips non-matching events to find an older match

```
24 passed in 0.55s
```

Live-verified end-to-end against a Jetson worker:
- `wait_for_event` resolves immediately from the ring buffer for fast tasks (3/3 race-repro runs pass).
- Resource subscriptions confirmed: `notifications/resources/updated` arrives at a Python MCP client subscribed to `events://devices/jetson-01/latest`; `resources/read` returns the payload.