### PR TITLE
feat(portal): coding agents — agent API, CLI, and self-service tab

### DIFF
--- a/packages/device-connect-server/device_connect_server/portal/README.md
+++ b/packages/device-connect-server/device_connect_server/portal/README.md
@@ -164,6 +164,128 @@ All settings are via environment variables:
 | POST | `/api/admin/nats/reload` | Regenerate config + SIGHUP |
 | POST | `/api/admin/health/verify` | Run isolation verification |
 
+### Agent API (`/api/agent/v1/*`, requires Bearer token)
+
+JSON-only namespace for coding agents and CI clients. Distinct from browser
+routes — never returns HTML, never redirects. Errors are JSON 401/403/4xx
+with `{"success": false, "error": {"code", "message"}}`.
+
+Auth: `Authorization: Bearer dcp_...`. Tokens carry per-request scopes:
+`devices:read`, `devices:provision`, `devices:credentials`, `devices:invoke`,
+`events:read`, `admin:tenants`, `admin:*`.
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET    | `/api/agent/v1/me` | (any) | Token identity + scopes |
+| GET    | `/api/agent/v1/fleet` | `devices:read` | Fleet summary |
+| GET    | `/api/agent/v1/devices` | `devices:read` | Paginated device list |
+| GET    | `/api/agent/v1/devices/{id}` | `devices:read` | Whole device record |
+| GET    | `/api/agent/v1/devices/{id}/identity` | `devices:read` | Whole `identity` sub-object |
+| GET    | `/api/agent/v1/devices/{id}/status` | `devices:read` | Whole `status` sub-object |
+| GET    | `/api/agent/v1/devices/{id}/capabilities` | `devices:read` | `{functions, events}` |
+| GET    | `/api/agent/v1/devices/{id}/functions` | `devices:read` | `capabilities.functions` |
+| GET    | `/api/agent/v1/devices/{id}/events` | `devices:read` | `capabilities.events` |
+| POST   | `/api/agent/v1/devices` | `devices:provision` | Create device + return creds inline |
+| GET    | `/api/agent/v1/devices/{id}/credentials` | `devices:credentials` | Re-download creds |
+| POST   | `/api/agent/v1/devices/{id}/credentials:rotate` | `devices:credentials` | Rotate creds |
+| DELETE | `/api/agent/v1/devices/{id}` | `devices:provision` | Decommission |
+| POST   | `/api/agent/v1/devices/{id}/invoke` | `devices:invoke` | Invoke function |
+| POST   | `/api/agent/v1/invoke-with-fallback` | `devices:invoke` | Try device list in order |
+| GET    | `/api/agent/v1/devices/{id}/events/{event}/stream` | `events:read` | Bounded NDJSON/SSE stream |
+
+Tenant override (`?tenant=other`) requires admin role plus `admin:tenants` or `admin:*`.
+
+#### Bounded event stream
+
+The `stream` endpoint refuses to start unless one of `duration`, `count`, or
+`follow=true` is supplied — agents can't accidentally hang on an unbounded
+stream. Server hard caps: 1 hour duration, 10 000 events. NDJSON output emits
+a final `_meta` line with `closed_by`, `events_received`, `elapsed_s`.
+
+```bash
+# At most 5 events or 30 seconds, whichever first
+curl -H "Authorization: Bearer $DEVICE_CONNECT_PORTAL_TOKEN" \
+  "$DEVICE_CONNECT_PORTAL_URL/api/agent/v1/devices/cam-001/events/motion/stream?format=ndjson&count=5&duration=30"
+```
+
+## Token management (`dc-portalctl` + admin CLI)
+
+Mint the first token from the portal host (writes directly to etcd):
+
+```bash
+python -m device_connect_server.portalctl.admin_tokens create \
+    --user alice --tenant acme \
+    --scopes devices:read,devices:invoke,events:read \
+    --label ci-bot
+# → JSON record. The "token" field (dcp_...) is shown ONLY ONCE — save it.
+
+# List
+python -m device_connect_server.portalctl.admin_tokens list
+
+# Revoke
+python -m device_connect_server.portalctl.admin_tokens revoke --token-id <id>
+```
+
+## `dc-portalctl` — agent-facing CLI
+
+Configure once:
+
+```bash
+export DEVICE_CONNECT_PORTAL_URL=http://localhost:8080
+export DEVICE_CONNECT_PORTAL_TOKEN=dcp_...
+```
+
+Read-only inspection:
+
+```bash
+dc-portalctl auth me
+dc-portalctl fleet describe
+dc-portalctl devices list
+dc-portalctl devices identity acme-cam-001
+dc-portalctl devices status acme-cam-001        # whole status sub-object
+dc-portalctl devices capabilities acme-cam-001  # {functions, events}
+dc-portalctl devices functions acme-cam-001
+dc-portalctl devices events acme-cam-001
+```
+
+Provisioning + credentials:
+
+```bash
+# Create + receive credentials inline; pipe to a file
+dc-portalctl devices provision cam-001 \
+    --device-type camera --location warehouse1/loading-dock \
+    --creds-output-file ./acme-cam-001.creds.json
+
+# Re-download
+dc-portalctl devices credentials acme-cam-001 --output-file ./acme-cam-001.creds.json
+```
+
+Invocation:
+
+```bash
+dc-portalctl devices invoke acme-cam-001 capture_frame \
+    --params '{"resolution":"4k"}' \
+    --reason "Daily inspection job"
+
+dc-portalctl devices invoke-fallback acme-cam-001,acme-cam-002 capture_frame \
+    --params '{}' --reason "Fallback to backup"
+```
+
+Bounded event stream — at least one of `--duration`, `--count`, `--follow`
+must be supplied:
+
+```bash
+# Up to 5 events, no longer than 30 s, whichever fires first
+dc-portalctl devices stream acme-cam-001 motion_detected \
+    --duration 30 --count 5 --format ndjson
+
+# Explicit unbounded (still capped server-side)
+dc-portalctl devices stream acme-cam-001 motion_detected --follow
+```
+
+Exit codes: `0` ok; `2` no events received within duration window or argument
+error; `4` 401; `5` 403; `6` 404; `1` other.
+
 ## Tech Stack
 
 - **aiohttp** + **aiohttp-jinja2** — async HTTP server with Jinja2 templates

--- a/packages/device-connect-server/device_connect_server/portal/README.md
+++ b/packages/device-connect-server/device_connect_server/portal/README.md
@@ -19,13 +19,19 @@ The portal runs alongside the existing NATS + etcd + registry stack. It stores u
 ## Prerequisites
 
 - **Docker & Docker Compose** (v2)
-- **nsc** — NATS credential toolchain (only needed for local/non-Docker runs)
+- **nsc** — NATS credential toolchain. Required on the host for both Docker and non-Docker runs, because `security_infra/setup_deployment.sh` (the one-time JWT bootstrap) and `manage_tenants.sh` shell out to it on the host.
   ```bash
   # macOS
   brew install nsc
-  # Linux / Go
+
+  # Linux / Go (installs to $(go env GOPATH)/bin — symlink onto PATH if needed)
   go install github.com/nats-io/nsc/v2@latest
+  sudo ln -sf "$(go env GOPATH)/bin/nsc" /usr/local/bin/nsc
+
+  # Or grab a prebuilt binary
+  # https://github.com/nats-io/nsc/releases
   ```
+  Verify with `nsc --version` before continuing.
 
 ## Quick Start (Docker Compose)
 
@@ -34,18 +40,29 @@ This is the recommended way to run the portal. It starts NATS, etcd, the registr
 ```bash
 cd packages/device-connect-server
 
-# 1. Start the full stack
+# 1. One-time JWT bootstrap. Requires `nsc` on PATH (see Prerequisites above).
+#    This generates security_infra/nats-jwt-generated.conf and the privileged
+#    credentials NATS needs to start. Use your machine's LAN IP (or public
+#    hostname) so devices can reach NATS.
+which nsc || { echo "install nsc first - see Prerequisites"; exit 1; }
+cd security_infra
+./setup_deployment.sh --nats-host <PUBLIC_HOST_OR_IP>
+cd ..
+
+# 2. Start the full stack
 docker compose -f infra/docker-compose-multitenant-nats.yml up -d --build portal
 
-# 2. Open the portal
+# 3. Open the portal
 open http://localhost:8080
 ```
 
-That's it. On first launch:
+> **Why step 1?** The NATS container bind-mounts `security_infra/nats-jwt-generated.conf` as its config. The compose file uses `create_host_path: false`, so if you skip step 1 the stack will fail fast with a clear error instead of silently creating an empty directory and crash-looping NATS.
+
+On first launch:
 
 1. Log in as **admin** with the password from the container logs (or the `ADMIN_PASS` env var if you set one)
-2. Go to **Admin > Setup** and enter the NATS host (use `nats` if running inside Docker, or your machine's IP if devices connect from outside)
-3. The bootstrap creates the NATS operator, account, and privileged credentials
+2. Go to **Admin > Setup** to confirm the bootstrap state — the operator/account from step 1 should already be present
+3. As tenants sign up, click **Reload NATS** in the admin UI to regenerate the config and SIGHUP the NATS container
 
 Users can now self-register at `/signup`.
 

--- a/packages/device-connect-server/device_connect_server/portal/README.md
+++ b/packages/device-connect-server/device_connect_server/portal/README.md
@@ -167,6 +167,7 @@ All settings are via environment variables:
 | GET | `/api/devices/live` | Live device table (htmx polling) |
 | GET | `/api/devices/{name}/creds` | Download credential file |
 | GET | `/api/devices/bundle` | Download all credentials as .zip |
+| GET/POST | `/auth/cli/{request_id}` | Browser-mediated CLI login: approve / deny a `dc-portalctl auth login` request |
 
 ### Admin (requires admin role)
 
@@ -193,6 +194,8 @@ Auth: `Authorization: Bearer dcp_...`. Tokens carry per-request scopes:
 
 | Method | Path | Scope | Description |
 |--------|------|-------|-------------|
+| POST   | `/api/agent/v1/auth/cli/init` | (public) | Start a browser-mediated CLI login; returns `request_id` + verification URL |
+| POST   | `/api/agent/v1/auth/cli/poll` | (public) | Poll until the user approves; returns the minted token (single-use) |
 | GET    | `/api/agent/v1/me` | (any) | Token identity + scopes |
 | GET    | `/api/agent/v1/fleet` | `devices:read` | Fleet summary |
 | GET    | `/api/agent/v1/devices` | `devices:read` | Paginated device list |
@@ -225,34 +228,53 @@ curl -H "Authorization: Bearer $DEVICE_CONNECT_PORTAL_TOKEN" \
   "$DEVICE_CONNECT_PORTAL_URL/api/agent/v1/devices/cam-001/events/motion/stream?format=ndjson&count=5&duration=30"
 ```
 
-## Token management (`dc-portalctl` + admin CLI)
-
-Mint the first token from the portal host (writes directly to etcd):
-
-```bash
-python -m device_connect_server.portalctl.admin_tokens create \
-    --user alice --tenant acme \
-    --scopes devices:read,devices:invoke,events:read \
-    --label ci-bot
-# → JSON record. The "token" field (dcp_...) is shown ONLY ONCE — save it.
-
-# List
-python -m device_connect_server.portalctl.admin_tokens list
-
-# Revoke
-python -m device_connect_server.portalctl.admin_tokens revoke --token-id <id>
-```
-
 ## `dc-portalctl` — agent-facing CLI
 
-Configure once:
+### Configure
 
 ```bash
-export DEVICE_CONNECT_PORTAL_URL=http://localhost:8080
-export DEVICE_CONNECT_PORTAL_TOKEN=dcp_...
+export DEVICE_CONNECT_PORTAL_URL=http://your-portal:8080
 ```
 
-Read-only inspection:
+### Log in (browser-mediated)
+
+```bash
+dc-portalctl auth login
+# Open this URL in your browser to approve CLI access:
+#
+#   http://your-portal:8080/auth/cli/<request_id>
+#
+# Requested scopes: devices:read, devices:provision, devices:credentials, devices:invoke, events:read
+# Waiting for approval (Ctrl-C to cancel)... .....
+# Logged in as alice (acme) — scopes: devices:invoke, devices:read, events:read.
+# Token saved to /home/alice/.config/dc-portalctl/token.
+```
+
+The CLI prints a verification URL, you open it in any browser, sign in to the
+portal (the post-login redirect lands you back on the approval page), review
+the requested scopes, and click **Approve**. The portal mints a token bound to
+your account and the CLI's poll picks it up. The token is cached at
+`~/.config/dc-portalctl/token` (mode `0600`); subsequent commands use it
+automatically. The verification record is single-use — once polled, it's
+deleted.
+
+Defaults:
+
+- Scopes: `devices:read, devices:provision, devices:credentials, devices:invoke, events:read` (override with `--scopes`)
+- TTL: 10 minutes to approve before the request expires
+- Non-admin users cannot grant `admin:*` scopes; those are silently dropped on approval
+
+Other auth commands:
+
+```bash
+dc-portalctl auth me               # show identity + scopes for the current token
+dc-portalctl auth logout           # remove the cached token
+```
+
+You can also pass a token explicitly via `--token` or `DEVICE_CONNECT_PORTAL_TOKEN`.
+Resolution order: `--token` > `$DEVICE_CONNECT_PORTAL_TOKEN` > `~/.config/dc-portalctl/token`.
+
+### Read-only inspection
 
 ```bash
 dc-portalctl auth me
@@ -265,7 +287,7 @@ dc-portalctl devices functions acme-cam-001
 dc-portalctl devices events acme-cam-001
 ```
 
-Provisioning + credentials:
+### Provisioning + credentials
 
 ```bash
 # Create + receive credentials inline; pipe to a file
@@ -277,7 +299,7 @@ dc-portalctl devices provision cam-001 \
 dc-portalctl devices credentials acme-cam-001 --output-file ./acme-cam-001.creds.json
 ```
 
-Invocation:
+### Invocation
 
 ```bash
 dc-portalctl devices invoke acme-cam-001 capture_frame \
@@ -288,8 +310,9 @@ dc-portalctl devices invoke-fallback acme-cam-001,acme-cam-002 capture_frame \
     --params '{}' --reason "Fallback to backup"
 ```
 
-Bounded event stream — at least one of `--duration`, `--count`, `--follow`
-must be supplied:
+### Bounded event stream
+
+At least one of `--duration`, `--count`, `--follow` must be supplied:
 
 ```bash
 # Up to 5 events, no longer than 30 s, whichever fires first
@@ -300,8 +323,30 @@ dc-portalctl devices stream acme-cam-001 motion_detected \
 dc-portalctl devices stream acme-cam-001 motion_detected --follow
 ```
 
-Exit codes: `0` ok; `2` no events received within duration window or argument
-error; `4` 401; `5` 403; `6` 404; `1` other.
+### Exit codes
+
+`0` ok; `2` no events received within duration window or argument error; `4` 401; `5` 403; `6` 404; `1` other.
+
+## Admin token operations (fallback)
+
+`auth login` is the recommended path. For automated/headless setup or to mint
+a token for another user, run the admin tool directly on the portal host
+(writes to etcd, no Bearer required):
+
+```bash
+python -m device_connect_server.portalctl.admin_tokens create \
+    --user alice --tenant acme \
+    --scopes devices:read,devices:invoke,events:read \
+    --label ci-bot
+# → JSON record. The "token" field (dcp_...) is shown ONLY ONCE — save it.
+
+python -m device_connect_server.portalctl.admin_tokens list
+python -m device_connect_server.portalctl.admin_tokens revoke --token-id <id>
+```
+
+This is also the only way to mint admin (`admin:*`) tokens, since the browser
+flow clamps non-admin grants and admins are typically expected to manage
+tokens from a controlled host.
 
 ## Tech Stack
 

--- a/packages/device-connect-server/device_connect_server/portal/README.md
+++ b/packages/device-connect-server/device_connect_server/portal/README.md
@@ -135,6 +135,7 @@ All settings are via environment variables:
    python your_device.py
    ```
 6. **Watch it appear**: the device shows up in the Live Devices panel on your dashboard within seconds
+7. **Hand off to a coding agent**: go to `/coding-agents` to download a tenant-specific `AGENTS.md` playbook, mint API tokens (one-time secret), or revoke them. Best for connecting Cursor / GitHub Actions / any agent that doesn't run `dc-portalctl auth login`.
 
 ### Account Model
 
@@ -168,6 +169,11 @@ All settings are via environment variables:
 | GET | `/api/devices/{name}/creds` | Download credential file |
 | GET | `/api/devices/bundle` | Download all credentials as .zip |
 | GET/POST | `/auth/cli/{request_id}` | Browser-mediated CLI login: approve / deny a `dc-portalctl auth login` request |
+| GET | `/coding-agents` | Coding Agents tab: AGENTS.md download + token management UI |
+| GET | `/coding-agents/AGENTS.md` | Tenant-rendered agent playbook (Markdown attachment) |
+| GET | `/coding-agents/tokens` | HTMX fragment: list current user's active tokens |
+| POST | `/coding-agents/tokens` | Mint a new token (label + scope checkboxes); returns one-time secret |
+| POST | `/coding-agents/tokens/{token_id}/revoke` | Revoke (owner or admin only) |
 
 ### Admin (requires admin role)
 
@@ -329,9 +335,11 @@ dc-portalctl devices stream acme-cam-001 motion_detected --follow
 
 ## Admin token operations (fallback)
 
-`auth login` is the recommended path. For automated/headless setup or to mint
-a token for another user, run the admin tool directly on the portal host
-(writes to etcd, no Bearer required):
+`auth login` is the recommended path for CLI use; the **Coding Agents tab**
+(`/coding-agents`) is the recommended path for non-admin users who want to
+mint, list, or revoke their own tokens from the browser. For automated/headless
+setup, or to mint a token for another user, run the admin tool directly on
+the portal host (writes to etcd, no Bearer required):
 
 ```bash
 python -m device_connect_server.portalctl.admin_tokens create \

--- a/packages/device-connect-server/device_connect_server/portal/app.py
+++ b/packages/device-connect-server/device_connect_server/portal/app.py
@@ -22,15 +22,46 @@ STATIC_DIR = Path(__file__).parent / "static"
 # Routes that don't require authentication
 PUBLIC_ROUTES = {"/", "/login", "/signup", "/api/login", "/api/signup"}
 
+# Agent API namespace — Bearer-token authenticated, JSON-only errors.
+AGENT_API_PREFIX = "/api/agent/v1/"
+
+
+def _json_error(status: int, code: str, message: str) -> web.Response:
+    return web.json_response(
+        {"success": False, "error": {"code": code, "message": message}},
+        status=status,
+    )
+
 
 @web.middleware
 async def auth_middleware(request: web.Request, handler):
-    """Redirect unauthenticated users to login page."""
+    """Authenticate browser sessions via cookie, agent API via Bearer token."""
     path = request.path
+
     # Allow public routes and static files
     if path in PUBLIC_ROUTES or path.startswith("/static"):
         return await handler(request)
 
+    # Agent API: Bearer token, JSON 401/403 — never HTML, never redirects.
+    if path.startswith(AGENT_API_PREFIX):
+        from .services import tokens as tokens_svc
+
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            return _json_error(401, "missing_token", "Authorization: Bearer <token> required")
+        token = auth_header[len("Bearer "):].strip()
+        record = tokens_svc.verify_token(token)
+        if not record:
+            return _json_error(401, "invalid_token", "Token is invalid, revoked, or expired")
+        request["token"] = record
+        request["user"] = {
+            "username": record["username"],
+            "tenant": record["tenant"],
+            "role": record["role"],
+        }
+        return await handler(request)
+
+    # Browser session path
     session = await _get_session(request)
     if not session.get("username"):
         if request.headers.get("HX-Request"):
@@ -119,11 +150,12 @@ def create_app() -> web.Application:
     app.router.add_static("/static", STATIC_DIR, name="static")
 
     # Register routes
-    from .views import auth, dashboard, devices, admin
+    from .views import auth, dashboard, devices, admin, agent_api
     auth.setup_routes(app)
     dashboard.setup_routes(app)
     devices.setup_routes(app)
     admin.setup_routes(app)
+    agent_api.setup_routes(app)
 
     # Seed admin on startup
     app.on_startup.append(_on_startup)

--- a/packages/device-connect-server/device_connect_server/portal/app.py
+++ b/packages/device-connect-server/device_connect_server/portal/app.py
@@ -25,6 +25,10 @@ PUBLIC_ROUTES = {"/", "/login", "/signup", "/api/login", "/api/signup"}
 # Agent API namespace — Bearer-token authenticated, JSON-only errors.
 AGENT_API_PREFIX = "/api/agent/v1/"
 
+# Subpaths under the agent API that are intentionally public (no Bearer required).
+# These power the browser-mediated CLI login flow.
+AGENT_API_PUBLIC_SUBPATHS = ("auth/cli/init", "auth/cli/poll")
+
 
 def _json_error(status: int, code: str, message: str) -> web.Response:
     return web.json_response(
@@ -44,6 +48,10 @@ async def auth_middleware(request: web.Request, handler):
 
     # Agent API: Bearer token, JSON 401/403 — never HTML, never redirects.
     if path.startswith(AGENT_API_PREFIX):
+        suffix = path[len(AGENT_API_PREFIX):]
+        if any(suffix == p or suffix.startswith(p + "/") for p in AGENT_API_PUBLIC_SUBPATHS):
+            return await handler(request)
+
         from .services import tokens as tokens_svc
 
         auth_header = request.headers.get("Authorization", "")
@@ -64,11 +72,18 @@ async def auth_middleware(request: web.Request, handler):
     # Browser session path
     session = await _get_session(request)
     if not session.get("username"):
+        # Preserve the requested URL so post-login redirect lands the user
+        # back on (e.g.) the CLI approval page.
+        next_url = path
+        if request.query_string:
+            next_url = f"{path}?{request.query_string}"
+        from urllib.parse import quote
+        login_url = "/login?next=" + quote(next_url, safe="") if path != "/login" else "/login"
         if request.headers.get("HX-Request"):
             resp = web.Response(status=200)
-            resp.headers["HX-Redirect"] = "/login"
+            resp.headers["HX-Redirect"] = login_url
             return resp
-        raise web.HTTPFound("/login")
+        raise web.HTTPFound(login_url)
 
     request["user"] = session
     return await handler(request)
@@ -150,12 +165,13 @@ def create_app() -> web.Application:
     app.router.add_static("/static", STATIC_DIR, name="static")
 
     # Register routes
-    from .views import auth, dashboard, devices, admin, agent_api
+    from .views import auth, dashboard, devices, admin, agent_api, cli_auth as cli_auth_view
     auth.setup_routes(app)
     dashboard.setup_routes(app)
     devices.setup_routes(app)
     admin.setup_routes(app)
     agent_api.setup_routes(app)
+    cli_auth_view.setup_routes(app)
 
     # Seed admin on startup
     app.on_startup.append(_on_startup)

--- a/packages/device-connect-server/device_connect_server/portal/app.py
+++ b/packages/device-connect-server/device_connect_server/portal/app.py
@@ -165,13 +165,17 @@ def create_app() -> web.Application:
     app.router.add_static("/static", STATIC_DIR, name="static")
 
     # Register routes
-    from .views import auth, dashboard, devices, admin, agent_api, cli_auth as cli_auth_view
+    from .views import (
+        auth, dashboard, devices, admin, agent_api,
+        cli_auth as cli_auth_view, coding_agents,
+    )
     auth.setup_routes(app)
     dashboard.setup_routes(app)
     devices.setup_routes(app)
     admin.setup_routes(app)
     agent_api.setup_routes(app)
     cli_auth_view.setup_routes(app)
+    coding_agents.setup_routes(app)
 
     # Seed admin on startup
     app.on_startup.append(_on_startup)

--- a/packages/device-connect-server/device_connect_server/portal/services/cli_auth.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/cli_auth.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Browser-mediated CLI auth flow (device authorization grant).
+
+The CLI calls `init` (no auth) to get a `request_id` and prints a verification
+URL the user opens in their browser. After login, the user clicks Approve;
+the portal mints a scoped token bound to the logged-in user and attaches it
+to the pending record. The CLI's `poll` returns the token and the record is
+consumed (deleted) on first successful read.
+
+Records live at /device-connect/portal/cli_auth/{request_id} in etcd.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from .. import config
+from . import tokens as tokens_svc
+
+logger = logging.getLogger(__name__)
+
+_PREFIX = "/device-connect/portal/cli_auth/"
+
+# Status enum
+PENDING = "pending"
+APPROVED = "approved"
+DENIED = "denied"
+
+# Lifetimes
+DEFAULT_TTL_SECONDS = 600           # 10 min — user has this long to click approve
+POLL_INTERVAL_SECONDS = 3
+
+# Scopes a regular (non-admin) user is allowed to grant via the browser flow.
+REGULAR_SCOPES = frozenset({
+    "devices:read",
+    "devices:provision",
+    "devices:credentials",
+    "devices:invoke",
+    "events:read",
+})
+
+
+class CliAuthError(Exception):
+    """Raised when a CLI auth operation fails."""
+
+
+def _etcd_client():
+    from etcd3gw import Etcd3Client
+    return Etcd3Client(host=config.ETCD_HOST, port=config.ETCD_PORT)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _expires_in_iso(seconds: int) -> str:
+    return (datetime.now(timezone.utc) + timedelta(seconds=seconds)).isoformat()
+
+
+def _is_expired(record: dict) -> bool:
+    exp = record.get("expires_at")
+    if not exp:
+        return False
+    try:
+        return datetime.fromisoformat(exp) <= datetime.now(timezone.utc)
+    except (ValueError, TypeError):
+        return True
+
+
+def init(*, scopes_requested: list[str], label: str = "",
+         ttl_seconds: int = DEFAULT_TTL_SECONDS) -> dict:
+    """Create a pending CLI-auth request. Returns the public-facing record."""
+    # Validate up-front so the CLI fails before printing a URL.
+    try:
+        cleaned = tokens_svc.validate_scopes(scopes_requested)
+    except ValueError as e:
+        raise CliAuthError(str(e))
+    if not cleaned:
+        raise CliAuthError("scopes_requested must include at least one scope")
+
+    request_id = secrets.token_hex(16)  # 32 hex chars
+    record = {
+        "request_id": request_id,
+        "scopes_requested": cleaned,
+        "label": label or "",
+        "status": PENDING,
+        "created_at": _now_iso(),
+        "expires_at": _expires_in_iso(ttl_seconds),
+        "approved_by": None,
+        "tenant": None,
+        "scopes_granted": None,
+        "token": None,            # full wire-format token, returned ONCE then consumed
+        "token_id": None,
+    }
+    client = _etcd_client()
+    client.put(_PREFIX + request_id, json.dumps(record))
+    logger.info("CLI auth init: request_id=%s scopes=%s label=%s",
+                request_id, cleaned, label)
+    return {"request_id": request_id,
+            "scopes_requested": cleaned,
+            "label": label,
+            "expires_at": record["expires_at"],
+            "poll_interval": POLL_INTERVAL_SECONDS}
+
+
+def get(request_id: str) -> dict | None:
+    """Fetch a record by id. Excludes the token field."""
+    record = _get_full(request_id)
+    if record is None:
+        return None
+    public = dict(record)
+    public.pop("token", None)
+    return public
+
+
+def _get_full(request_id: str) -> dict | None:
+    client = _etcd_client()
+    values = client.get(_PREFIX + request_id)
+    if not values:
+        return None
+    raw = values[0]
+    if isinstance(raw, bytes):
+        raw = raw.decode()
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _put(record: dict) -> None:
+    client = _etcd_client()
+    client.put(_PREFIX + record["request_id"], json.dumps(record))
+
+
+def _delete(request_id: str) -> None:
+    client = _etcd_client()
+    try:
+        client.delete(_PREFIX + request_id)
+    except Exception:
+        # etcd3gw delete API varies between versions — best effort
+        try:
+            client.delete_range(_PREFIX + request_id)  # type: ignore[attr-defined]
+        except Exception:
+            logger.debug("cli_auth: failed to delete %s", request_id, exc_info=True)
+
+
+def _clamp_scopes(requested: list[str], role: str) -> list[str]:
+    if role == "admin":
+        return list(requested)
+    return [s for s in requested if s in REGULAR_SCOPES]
+
+
+def approve(*, request_id: str, user: dict, scopes_granted: list[str] | None = None) -> dict:
+    """Mark a pending record approved and mint a token bound to the user.
+
+    `user` must contain at least: username, tenant, role.
+    `scopes_granted` defaults to the originally requested scopes, clamped by
+    what the approving user is allowed to grant given their role.
+    """
+    record = _get_full(request_id)
+    if record is None:
+        raise CliAuthError("request_id not found")
+    if record["status"] != PENDING:
+        raise CliAuthError(f"request is already {record['status']}")
+    if _is_expired(record):
+        record["status"] = "expired"
+        _put(record)
+        raise CliAuthError("request has expired")
+
+    requested = list(record.get("scopes_requested") or [])
+    granted_in = list(scopes_granted) if scopes_granted is not None else requested
+    granted = [s for s in granted_in if s in requested]
+    granted = _clamp_scopes(granted, user.get("role", "user"))
+    if not granted:
+        raise CliAuthError("no scopes granted")
+
+    minted = tokens_svc.create_token(
+        username=user["username"],
+        tenant=user["tenant"],
+        role=user.get("role", "user"),
+        scopes=granted,
+        label=record.get("label") or f"cli-login {user['username']}",
+    )
+    record["status"] = APPROVED
+    record["approved_by"] = user["username"]
+    record["tenant"] = user["tenant"]
+    record["scopes_granted"] = minted["scopes"]
+    record["token"] = minted["token"]
+    record["token_id"] = minted["token_id"]
+    record["approved_at"] = _now_iso()
+    _put(record)
+    logger.info("CLI auth approved: request_id=%s by=%s scopes=%s",
+                request_id, user["username"], minted["scopes"])
+    return get(request_id)
+
+
+def deny(*, request_id: str, user: dict | None = None) -> dict:
+    record = _get_full(request_id)
+    if record is None:
+        raise CliAuthError("request_id not found")
+    if record["status"] != PENDING:
+        raise CliAuthError(f"request is already {record['status']}")
+    record["status"] = DENIED
+    if user:
+        record["approved_by"] = user.get("username")
+    record["denied_at"] = _now_iso()
+    _put(record)
+    logger.info("CLI auth denied: request_id=%s by=%s", request_id, user and user.get("username"))
+    return get(request_id)
+
+
+def consume_on_poll(request_id: str) -> tuple[str, dict | None]:
+    """Poll a record. On success, return the wire-format token and DELETE the record.
+
+    Returns (status, payload) where:
+      - status="approved":  payload={token, scopes, username, tenant, token_id} — record deleted
+      - status="pending":   payload=None
+      - status="denied":    payload=None — record deleted
+      - status="expired":   payload=None — record deleted
+      - status="not_found": payload=None
+    """
+    record = _get_full(request_id)
+    if record is None:
+        return "not_found", None
+
+    if record["status"] == APPROVED:
+        payload = {
+            "token": record["token"],
+            "scopes": record["scopes_granted"],
+            "username": record["approved_by"],
+            "tenant": record["tenant"],
+            "token_id": record["token_id"],
+        }
+        _delete(request_id)
+        return "approved", payload
+
+    if _is_expired(record):
+        _delete(request_id)
+        return "expired", None
+
+    if record["status"] == DENIED:
+        _delete(request_id)
+        return "denied", None
+
+    return "pending", None

--- a/packages/device-connect-server/device_connect_server/portal/services/tokens.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/tokens.py
@@ -105,7 +105,7 @@ def create_token(
     """
     scopes = validate_scopes(scopes)
 
-    token_id = secrets.token_hex(8)  # 16 hex chars
+    token_id = secrets.token_hex(16)  # 32 hex chars / 128 bits — collision-resistant
     secret = secrets.token_urlsafe(32)
     secret_hash = _hash_secret(secret)
 

--- a/packages/device-connect-server/device_connect_server/portal/services/tokens.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/tokens.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bearer token issuance + verification for the agent API.
+
+Tokens are stored in etcd under /device-connect/portal/tokens/{token_id}.
+Only the SHA-256 hash of the token secret is persisted; the secret itself
+is returned exactly once at creation time and is never recoverable.
+
+Token wire format: "dcp_{token_id}_{secret}"
+- token_id: 16-hex-char random id, used as the etcd lookup key
+- secret:   32-byte urlsafe-base64 random string, only its hash is stored
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import secrets
+from datetime import datetime, timezone
+
+from .. import config
+
+logger = logging.getLogger(__name__)
+
+_TOKENS_PREFIX = "/device-connect/portal/tokens/"
+
+TOKEN_PREFIX = "dcp_"
+
+# All scopes recognized by the agent API. Anything else is rejected at create-time.
+KNOWN_SCOPES = frozenset({
+    "devices:read",
+    "devices:provision",
+    "devices:credentials",
+    "devices:invoke",
+    "events:read",
+    "admin:tenants",
+    "admin:*",
+})
+
+
+class TokenError(Exception):
+    """Raised when a token operation fails."""
+
+
+def _etcd_client():
+    from etcd3gw import Etcd3Client
+    return Etcd3Client(host=config.ETCD_HOST, port=config.ETCD_PORT)
+
+
+def _hash_secret(secret: str) -> str:
+    return hashlib.sha256(secret.encode()).hexdigest()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_token(token: str) -> tuple[str, str] | None:
+    """Split a wire-format token into (token_id, secret). Returns None on malformed input."""
+    if not token or not token.startswith(TOKEN_PREFIX):
+        return None
+    rest = token[len(TOKEN_PREFIX):]
+    parts = rest.split("_", 1)
+    if len(parts) != 2:
+        return None
+    token_id, secret = parts
+    if not token_id or not secret:
+        return None
+    return token_id, secret
+
+
+def validate_scopes(scopes: list[str]) -> list[str]:
+    """Return a sorted, de-duped, validated scope list. Raises ValueError on unknown."""
+    cleaned = []
+    seen = set()
+    for s in scopes:
+        s = s.strip()
+        if not s or s in seen:
+            continue
+        if s not in KNOWN_SCOPES:
+            raise ValueError(f"Unknown scope: {s}")
+        cleaned.append(s)
+        seen.add(s)
+    cleaned.sort()
+    return cleaned
+
+
+def create_token(
+    *,
+    username: str,
+    tenant: str,
+    role: str,
+    scopes: list[str],
+    label: str = "",
+    expires_at: str | None = None,
+) -> dict:
+    """Mint a new token. Returns dict with full token secret in 'token' field.
+
+    The secret is only returned here. Subsequent reads via get_token_record /
+    list_tokens never expose it.
+    """
+    scopes = validate_scopes(scopes)
+
+    token_id = secrets.token_hex(8)  # 16 hex chars
+    secret = secrets.token_urlsafe(32)
+    secret_hash = _hash_secret(secret)
+
+    record = {
+        "token_id": token_id,
+        "username": username,
+        "tenant": tenant,
+        "role": role,
+        "scopes": scopes,
+        "label": label,
+        "secret_hash": secret_hash,
+        "created_at": _now_iso(),
+        "expires_at": expires_at,
+        "revoked": False,
+    }
+
+    client = _etcd_client()
+    client.put(_TOKENS_PREFIX + token_id, json.dumps(record))
+
+    full_token = f"{TOKEN_PREFIX}{token_id}_{secret}"
+    logger.info("Created agent token %s for user=%s tenant=%s scopes=%s",
+                token_id, username, tenant, scopes)
+
+    out = dict(record)
+    out.pop("secret_hash", None)
+    out["token"] = full_token  # only present on creation
+    return out
+
+
+def get_token_record(token_id: str) -> dict | None:
+    """Fetch a token record by id. Excludes secret_hash from the returned dict."""
+    client = _etcd_client()
+    values = client.get(_TOKENS_PREFIX + token_id)
+    if not values:
+        return None
+    raw = values[0]
+    if isinstance(raw, bytes):
+        raw = raw.decode()
+    try:
+        record = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    record.pop("secret_hash", None)
+    return record
+
+
+def _get_token_record_with_hash(token_id: str) -> dict | None:
+    """Internal: fetch token record including secret_hash for verification."""
+    client = _etcd_client()
+    values = client.get(_TOKENS_PREFIX + token_id)
+    if not values:
+        return None
+    raw = values[0]
+    if isinstance(raw, bytes):
+        raw = raw.decode()
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def list_tokens(username: str | None = None, tenant: str | None = None) -> list[dict]:
+    """List token records. Excludes secret_hash. Filters by user/tenant if given."""
+    client = _etcd_client()
+    out = []
+    for raw, _meta in client.get_prefix(_TOKENS_PREFIX):
+        if isinstance(raw, bytes):
+            raw = raw.decode()
+        try:
+            record = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if username and record.get("username") != username:
+            continue
+        if tenant and record.get("tenant") != tenant:
+            continue
+        record.pop("secret_hash", None)
+        out.append(record)
+    out.sort(key=lambda r: r.get("created_at", ""), reverse=True)
+    return out
+
+
+def revoke_token(token_id: str) -> bool:
+    """Mark a token as revoked. Returns True if it existed."""
+    client = _etcd_client()
+    values = client.get(_TOKENS_PREFIX + token_id)
+    if not values:
+        return False
+    raw = values[0]
+    if isinstance(raw, bytes):
+        raw = raw.decode()
+    try:
+        record = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    record["revoked"] = True
+    record["revoked_at"] = _now_iso()
+    client.put(_TOKENS_PREFIX + token_id, json.dumps(record))
+    logger.info("Revoked agent token %s", token_id)
+    return True
+
+
+def verify_token(token: str) -> dict | None:
+    """Verify a wire-format token. Returns the record (without secret_hash) on success.
+
+    Returns None on any failure: malformed, unknown id, hash mismatch, revoked,
+    or expired. Constant-time secret comparison.
+    """
+    parsed = _parse_token(token)
+    if not parsed:
+        return None
+    token_id, secret = parsed
+
+    record = _get_token_record_with_hash(token_id)
+    if not record:
+        return None
+
+    expected = record.get("secret_hash", "")
+    if not expected:
+        return None
+    if not hmac.compare_digest(expected, _hash_secret(secret)):
+        return None
+
+    if record.get("revoked"):
+        return None
+
+    expires_at = record.get("expires_at")
+    if expires_at:
+        try:
+            exp = datetime.fromisoformat(expires_at)
+            if exp <= datetime.now(timezone.utc):
+                return None
+        except (ValueError, TypeError):
+            return None
+
+    record.pop("secret_hash", None)
+    return record
+
+
+def has_scope(record: dict, required: str) -> bool:
+    """Return True if the token holds the required scope (or admin:* wildcard)."""
+    scopes = record.get("scopes", []) or []
+    if required in scopes:
+        return True
+    if required.startswith("admin:") and "admin:*" in scopes:
+        return True
+    return False

--- a/packages/device-connect-server/device_connect_server/portal/templates/auth/cli_approve.html
+++ b/packages/device-connect-server/device_connect_server/portal/templates/auth/cli_approve.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full bg-gray-50">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Approve CLI access — Device Connect Portal</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="h-full flex items-center justify-center">
+  <div class="w-full max-w-lg">
+    <div class="text-center mb-8">
+      <div class="inline-flex items-center justify-center w-12 h-12 bg-indigo-600 rounded-xl mb-4">
+        <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+        </svg>
+      </div>
+      <h1 class="text-2xl font-bold text-gray-900">Authorize CLI access</h1>
+      <p class="text-sm text-gray-500 mt-1">A coding agent or CLI is requesting an access token tied to your account</p>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+      {% if error %}
+        <div class="mb-4 rounded-lg p-3 bg-red-50 text-red-700 text-sm border border-red-200">{{ error }}</div>
+      {% endif %}
+
+      {% if approved %}
+        <div class="rounded-lg p-4 bg-green-50 text-green-800 border border-green-200">
+          <p class="font-semibold">Authorized.</p>
+          <p class="text-sm mt-1">You can return to your terminal — the CLI should pick up the token automatically.</p>
+          {% if record and record.scopes_granted %}
+            <p class="text-xs mt-3 text-green-700">
+              Granted scopes:
+              <code class="bg-white border border-green-200 rounded px-1">{{ record.scopes_granted | join(', ') }}</code>
+            </p>
+          {% endif %}
+        </div>
+      {% elif denied %}
+        <div class="rounded-lg p-4 bg-yellow-50 text-yellow-800 border border-yellow-200">
+          <p class="font-semibold">Denied.</p>
+          <p class="text-sm mt-1">The request was rejected. The CLI will receive an error.</p>
+        </div>
+      {% elif record %}
+        <div class="space-y-4">
+          <div>
+            <p class="text-sm text-gray-500">Logged in as</p>
+            <p class="text-base font-semibold text-gray-900">
+              {{ user.username }}
+              <span class="text-xs font-normal text-gray-500">({{ user.role }} · tenant {{ user.tenant }})</span>
+            </p>
+          </div>
+
+          {% if record.label %}
+            <div>
+              <p class="text-sm text-gray-500">Label</p>
+              <p class="text-sm text-gray-900">{{ record.label }}</p>
+            </div>
+          {% endif %}
+
+          <div>
+            <p class="text-sm text-gray-500">Requested scopes</p>
+            <ul class="mt-1 space-y-1">
+              {% for s in record.scopes_requested %}
+                <li class="text-sm text-gray-900">
+                  <code class="bg-gray-100 border border-gray-200 rounded px-1.5 py-0.5">{{ s }}</code>
+                </li>
+              {% endfor %}
+            </ul>
+            {% if user.role != 'admin' %}
+              <p class="text-xs text-gray-500 mt-2">Non-admin users cannot grant admin scopes; those will be silently dropped.</p>
+            {% endif %}
+          </div>
+
+          <form method="POST" action="/auth/cli/{{ request_id }}" class="flex gap-2 pt-2">
+            <button type="submit" name="action" value="approve"
+                    class="flex-1 bg-indigo-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+              Approve
+            </button>
+            <button type="submit" name="action" value="deny"
+                    class="flex-1 bg-white text-gray-700 border border-gray-300 rounded-lg px-4 py-2 text-sm font-medium hover:bg-gray-50">
+              Deny
+            </button>
+          </form>
+        </div>
+      {% endif %}
+    </div>
+
+    <p class="text-center text-xs text-gray-400 mt-4">
+      You can revoke this token later from <a href="/dashboard" class="underline">your dashboard</a>.
+    </p>
+  </div>
+</body>
+</html>

--- a/packages/device-connect-server/device_connect_server/portal/templates/base.html
+++ b/packages/device-connect-server/device_connect_server/portal/templates/base.html
@@ -29,6 +29,7 @@
           {% else %}
           <a href="/dashboard" class="text-sm {% if nav == 'dashboard' %}text-indigo-600 font-medium{% else %}text-gray-500 hover:text-gray-700{% endif %}">Dashboard</a>
           <a href="/devices" class="text-sm {% if nav == 'devices' %}text-indigo-600 font-medium{% else %}text-gray-500 hover:text-gray-700{% endif %}">My Devices</a>
+          <a href="/coding-agents" class="text-sm {% if nav == 'coding-agents' %}text-indigo-600 font-medium{% else %}text-gray-500 hover:text-gray-700{% endif %}">Coding Agents</a>
           {% endif %}
         </div>
         <div class="flex items-center space-x-4">

--- a/packages/device-connect-server/device_connect_server/portal/templates/coding_agents/AGENTS.md.j2
+++ b/packages/device-connect-server/device_connect_server/portal/templates/coding_agents/AGENTS.md.j2
@@ -1,0 +1,441 @@
+---
+name: device-connect
+description: Playbook for working with the Device Connect fleet on tenant `{{ tenant }}`. Load this when the user asks an agent to provision, launch, discover, invoke, or observe physical or simulated devices on this network.
+---
+
+# Device Connect — agent playbook
+
+You're working with a [Device Connect](https://github.com/arm/device-connect) fleet
+on tenant **`{{ tenant }}`**, served by the portal at **{{ portal_url }}**.
+Devices speak NATS and live under the namespace `device-connect.{{ tenant }}.>`,
+isolated from other tenants by JWT.
+
+This document is your playbook. Read top-to-bottom once, then jump to the
+section that matches what the user is asking for.
+
+## Tenant facts (substituted at download)
+
+- **Tenant:** `{{ tenant }}`
+- **Portal:** `{{ portal_url }}`
+- **NATS host:** `{{ public_host }}` (port `4222` unless overridden)
+- **Namespace:** `device-connect.{{ tenant }}.>`
+- **Example device id:** `{{ example_device_id }}` (tenant-prefixed; see "Provision")
+
+---
+
+## 1. First-time setup (run this yourself)
+
+You — the agent — are responsible for getting the CLI working. The user only
+needs to click Approve in the browser once. Install into a dedicated venv at
+`~/.dc-portalctl/venv` so it never collides with the project's own
+dependencies.
+
+```bash
+# 1. One-time: create the dedicated venv and install the CLI into it.
+#    Idempotent — safe to re-run; upgrades the CLI in place.
+python3 -m venv ~/.dc-portalctl/venv
+~/.dc-portalctl/venv/bin/pip install --upgrade pip
+~/.dc-portalctl/venv/bin/pip install --upgrade device-connect-server
+
+# 2. Put the venv's bin on PATH for this shell.
+#    (Add this line to ~/.bashrc or ~/.zshrc to persist it across sessions.)
+export PATH="$HOME/.dc-portalctl/venv/bin:$PATH"
+
+# 3. Point dc-portalctl at this portal.
+export DEVICE_CONNECT_PORTAL_URL={{ portal_url }}
+
+# 4. Browser-mediated login. Prints a verification URL — show it to the user
+#    and ask them to click Approve. The CLI's poll receives a fresh token and
+#    caches it at ~/.config/dc-portalctl/token; subsequent commands pick it up
+#    automatically.
+dc-portalctl auth login
+
+# 5. Confirm.
+dc-portalctl auth me
+```
+
+If `python3 -m venv` is blocked in your sandbox, try `pipx install
+device-connect-server` (which uses its own venv under the hood). If neither
+works, fall back to direct HTTP calls against `{{ portal_url }}/api/agent/v1/*`
+with a `DEVICE_CONNECT_PORTAL_TOKEN` minted at
+`{{ portal_url }}/coding-agents`.
+
+### CI / non-interactive use
+
+Skip the login flow entirely — mint a token at
+`{{ portal_url }}/coding-agents` and set:
+
+```bash
+export DEVICE_CONNECT_PORTAL_URL={{ portal_url }}
+export DEVICE_CONNECT_PORTAL_TOKEN=dcp_xxxxx_yyyyy
+```
+
+### Token scopes you may see
+
+- `devices:read` — list/describe devices
+- `devices:provision` — create / decommission devices
+- `devices:credentials` — re-download or rotate device credentials
+- `devices:invoke` — call functions
+- `events:read` — read event streams
+- `admin:tenants` / `admin:*` — admin only; do not request unless you are admin
+
+If you get `401 invalid_token`, the token was revoked or expired — run
+`dc-portalctl auth login` again. If you get `403`, the token doesn't have the
+scope you need; mint a new one with the right scopes at `{{ portal_url }}/coding-agents`.
+
+---
+
+## 2. Discover
+
+Use the four hierarchical meta-tools from `device-connect-agent-tools`. Always
+**start with `describe_fleet()`** to keep your context small — it's a summary,
+not a dump. Drill down only when the task needs it.
+
+| Tool | When |
+|---|---|
+| `describe_fleet()` | First call. Returns device-type counts and locations. |
+| `list_devices(device_type=…, location=…)` | Narrow down by a filter once you know the shape of the fleet. |
+| `get_device_functions(device_id)` | Read the schema of a device's RPCs before invoking. |
+| `invoke_device(device_id, function, params, llm_reasoning)` | Call a function. The reasoning string is mandatory and goes into the audit log. |
+
+Equivalent CLI:
+
+```bash
+dc-portalctl fleet describe
+dc-portalctl devices list
+dc-portalctl devices list --device-type camera --location warehouse1
+dc-portalctl devices capabilities {{ example_device_id }}
+dc-portalctl devices functions {{ example_device_id }}
+```
+
+Equivalent HTTP:
+
+```bash
+curl -H "Authorization: Bearer $DEVICE_CONNECT_PORTAL_TOKEN" \
+  {{ portal_url }}/api/agent/v1/fleet
+curl -H "Authorization: Bearer $DEVICE_CONNECT_PORTAL_TOKEN" \
+  "{{ portal_url }}/api/agent/v1/devices?device_type=camera"
+curl -H "Authorization: Bearer $DEVICE_CONNECT_PORTAL_TOKEN" \
+  {{ portal_url }}/api/agent/v1/devices/{{ example_device_id }}/capabilities
+```
+
+---
+
+## 3. Provision a device
+
+Provisioning creates a NATS credential bound to this tenant and registers the
+device id with the portal. Device ids are tenant-prefixed: a request for
+`cam-001` lands as `{{ tenant }}-cam-001`.
+
+```bash
+dc-portalctl devices provision cam-001 \
+    --device-type camera \
+    --location warehouse1/loading-dock \
+    --creds-output-file ./{{ tenant }}-cam-001.creds.json
+```
+
+The `.creds.json` is a NATS JWT credential. Keep it secret — anyone with that
+file can connect as the device. To re-download:
+
+```bash
+dc-portalctl devices credentials {{ tenant }}-cam-001 \
+    --output-file ./{{ tenant }}-cam-001.creds.json
+```
+
+Equivalent HTTP (returns creds inline; needs `devices:provision` scope):
+
+```bash
+curl -X POST -H "Authorization: Bearer $DEVICE_CONNECT_PORTAL_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"device_name":"cam-001","device_type":"camera","location":"warehouse1/loading-dock"}' \
+  {{ portal_url }}/api/agent/v1/devices
+```
+
+To decommission: `DELETE /api/agent/v1/devices/{id}` or
+`dc-portalctl devices revoke-credentials …`. Decommission revokes the JWT —
+the device process will be disconnected on its next NATS reconnect.
+
+---
+
+## 4. Author a driver
+
+A "device" in Device Connect is any Python process that subclasses
+`DeviceDriver` and runs in `DeviceRuntime`. Four decorators cover everything:
+
+| Decorator | Purpose |
+|---|---|
+| `@rpc()` | Expose a coroutine method as a callable function |
+| `@emit()` | Mark a method as an event broadcaster (body is a no-op; framework publishes) |
+| `@periodic(interval=…)` | Run a method on a timer |
+| `@on(device_type=…, event_name=…)` | Subscribe to events from other devices (D2D) |
+
+Minimum viable driver:
+
+```python
+import asyncio, signal
+from device_connect_edge import DeviceRuntime
+from device_connect_edge.drivers import DeviceDriver, rpc, emit, periodic
+from device_connect_edge.types import DeviceIdentity, DeviceStatus
+
+
+class TempSensorDriver(DeviceDriver):
+    device_type = "temp_sensor"
+
+    @property
+    def identity(self) -> DeviceIdentity:
+        return DeviceIdentity(
+            device_type="temp_sensor",
+            manufacturer="ACME", model="T1", firmware_version="0.1.0",
+            description="Demo temperature sensor",
+        )
+
+    @property
+    def status(self) -> DeviceStatus:
+        return DeviceStatus(location="lab", availability="available")
+
+    @rpc()
+    async def get_reading(self) -> dict:
+        return {"temp_c": 22.5}
+
+    @emit()
+    async def temp_changed(self, temp_c: float):
+        """Framework publishes; method body unused."""
+
+    @periodic(interval=10.0)
+    async def heartbeat(self):
+        await self.temp_changed(temp_c=22.5)
+
+
+async def run():
+    device = DeviceRuntime(driver=TempSensorDriver())
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop.set)
+    task = asyncio.create_task(device.run())
+    await stop.wait()
+    await device.stop()
+    task.cancel()
+
+
+if __name__ == "__main__":
+    asyncio.run(run())
+```
+
+`device_id` and `tenant` are auto-detected from `NATS_CREDENTIALS_FILE`;
+don't hard-code them. For richer references see
+[`examples/dht22_sensor/device_driver.py`](https://github.com/arm/device-connect/blob/main/packages/device-connect-edge/examples/dht22_sensor/device_driver.py)
+(real GPIO hardware) and
+[`examples/number_generator/device_simulator.py`](https://github.com/arm/device-connect/blob/main/packages/device-connect-edge/examples/number_generator/device_simulator.py)
+(simulator).
+
+---
+
+## 5. Launch a device locally
+
+```bash
+export NATS_CREDENTIALS_FILE=./{{ tenant }}-cam-001.creds.json
+export NATS_URL=nats://{{ public_host }}:4222
+export DEVICE_CONNECT_ALLOW_INSECURE=true   # only for dev; drop in prod
+python my_device.py
+```
+
+Verify it came online:
+
+```bash
+dc-portalctl devices list | grep {{ tenant }}-cam-001
+# or watch the portal Dashboard at {{ portal_url }}/dashboard
+```
+
+If it doesn't appear within ~5 seconds, the most common causes are:
+
+1. NATS host unreachable from the device — confirm `nats://{{ public_host }}:4222` resolves and is open.
+2. Wrong creds file — `NATS_CREDENTIALS_FILE` must point at the device's own `.creds.json`, not another tenant's.
+3. Driver process crashed at startup — check stderr.
+
+---
+
+## 6. Launch a device on a remote host (SSH)
+
+The device process is just a Python script that needs the creds file plus
+network access to NATS. Workflow:
+
+```bash
+# 1. Provision (locally) and copy the creds file to the host that will run the device.
+dc-portalctl devices provision cam-001 --device-type camera \
+    --creds-output-file ./{{ tenant }}-cam-001.creds.json
+scp ./{{ tenant }}-cam-001.creds.json my_device.py user@edge-host:~/dc/
+
+# 2. Install device-connect-edge on the host (one-time per host).
+ssh user@edge-host "python3 -m pip install --user device-connect-edge"
+
+# 3. Run it (pinned to a tmux session so it survives the SSH disconnect).
+ssh user@edge-host "tmux new -d -s dc-cam-001 \
+    'cd ~/dc && \
+     NATS_CREDENTIALS_FILE=./{{ tenant }}-cam-001.creds.json \
+     NATS_URL=nats://{{ public_host }}:4222 \
+     python3 my_device.py 2>&1 | tee dc-cam-001.log'"
+
+# 4. Verify from the portal side.
+dc-portalctl devices list | grep {{ tenant }}-cam-001
+```
+
+For longer-lived deployments, prefer a systemd-user unit so the service auto-restarts:
+
+```ini
+# ~/.config/systemd/user/dc-cam-001.service
+[Service]
+WorkingDirectory=%h/dc
+Environment=NATS_CREDENTIALS_FILE=%h/dc/{{ tenant }}-cam-001.creds.json
+Environment=NATS_URL=nats://{{ public_host }}:4222
+ExecStart=/usr/bin/python3 %h/dc/my_device.py
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+ssh user@edge-host "systemctl --user daemon-reload && \
+                    systemctl --user enable --now dc-cam-001"
+
+# Tail logs
+ssh user@edge-host "journalctl --user -u dc-cam-001 -f"
+```
+
+To pull recent logs back without leaving a shell open:
+
+```bash
+ssh user@edge-host "journalctl --user -u dc-cam-001 --since '10 min ago'" \
+    > /tmp/dc-cam-001.log
+```
+
+---
+
+## 7. Invoke a function
+
+Always include `llm_reasoning` (the audit log requires a reason). The portal
+records who called what and why.
+
+```bash
+dc-portalctl devices invoke {{ example_device_id }} capture_frame \
+    --params '{"resolution":"4k"}' \
+    --reason "Daily inspection job"
+```
+
+For redundancy across interchangeable devices (try in order, return the first
+success):
+
+```bash
+dc-portalctl devices invoke-fallback {{ tenant }}-cam-001,{{ tenant }}-cam-002 \
+    capture_frame --params '{}' --reason "Primary down, fail over"
+```
+
+Equivalent HTTP (`devices:invoke` scope):
+
+```bash
+curl -X POST -H "Authorization: Bearer $DEVICE_CONNECT_PORTAL_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"function":"capture_frame","params":{"resolution":"4k"},"reason":"Daily inspection"}' \
+  {{ portal_url }}/api/agent/v1/devices/{{ example_device_id }}/invoke
+```
+
+Default per-call timeout is ~5 s. If the device is offline the call returns
+quickly with `not_available`; if it hangs the call returns `timeout`.
+
+---
+
+## 8. Observe events (and write integration tests)
+
+Event streams are **bounded** — agents can't accidentally hang forever. The
+server requires at least one of `duration`, `count`, or `follow=true`. Hard
+caps: 1 hour, 10 000 events.
+
+```bash
+# Up to 5 events or 30 seconds, whichever comes first
+dc-portalctl devices stream {{ example_device_id }} motion_detected \
+    --duration 30 --count 5 --format ndjson
+```
+
+NDJSON output ends with a `_meta` line with `closed_by`,
+`events_received`, `elapsed_s` — use it to assert the stream closed for the
+right reason.
+
+### Recipe: cross-device integration test
+
+```bash
+# Provision two devices in the same tenant
+dc-portalctl devices provision sensor-001 --device-type sensor \
+    --creds-output-file ./{{ tenant }}-sensor-001.creds.json
+dc-portalctl devices provision controller-001 --device-type controller \
+    --creds-output-file ./{{ tenant }}-controller-001.creds.json
+
+# Start both (locally or via SSH per Section 6)
+
+# In one terminal: open a bounded stream on the controller's "alert" event
+dc-portalctl devices stream {{ tenant }}-controller-001 alert \
+    --duration 30 --count 1 --format ndjson > alerts.ndjson &
+
+# In another: invoke the sensor to produce a reading that should trigger
+dc-portalctl devices invoke {{ tenant }}-sensor-001 simulate_high_temp \
+    --params '{"temp_c": 45}' --reason "Integration test: assert controller reacts"
+
+# Assert: alerts.ndjson should contain a record with reason ~ "temp"
+wait
+grep -q '"action":"watering' alerts.ndjson && echo PASS || echo FAIL
+```
+
+The same pattern works from Python — call `invoke_device` then iterate the
+NDJSON/SSE stream until the `_meta` close line.
+
+---
+
+## 9. Rotate, list, and revoke API tokens
+
+Visit **{{ portal_url }}/coding-agents** to:
+
+- Mint a new token with the scopes you need (one-time secret display)
+- See your active tokens (label, scopes, created date)
+- Revoke any token immediately (any agent or job using it gets `401`
+  on its next call)
+
+For automated rotation, mint a fresh token, write it to wherever your agent
+reads `DEVICE_CONNECT_PORTAL_TOKEN` from, then revoke the old one through the
+same portal page.
+
+---
+
+## Quick reference
+
+```bash
+# Auth
+dc-portalctl auth login            # browser-mediated, caches token
+dc-portalctl auth me               # whoami + scopes
+dc-portalctl auth logout           # forget cached token
+
+# Fleet / devices
+dc-portalctl fleet describe
+dc-portalctl devices list [--device-type X --location Y]
+dc-portalctl devices identity     <id>
+dc-portalctl devices status       <id>
+dc-portalctl devices capabilities <id>
+dc-portalctl devices functions    <id>
+dc-portalctl devices events       <id>
+
+# Provisioning
+dc-portalctl devices provision    <name> --device-type X [--location Y] \
+    --creds-output-file <path>
+dc-portalctl devices credentials  <id> --output-file <path>
+dc-portalctl devices revoke-credentials <id>
+
+# Invocation
+dc-portalctl devices invoke          <id>          <fn> --params '{…}' --reason "…"
+dc-portalctl devices invoke-fallback <id>,<id>,…   <fn> --params '{…}' --reason "…"
+
+# Events (must specify --duration, --count, or --follow)
+dc-portalctl devices stream <id> <event> --duration N [--count K] [--format ndjson]
+```
+
+Exit codes: `0` ok, `2` no events / arg error, `4` 401, `5` 403, `6` 404,
+`1` other.

--- a/packages/device-connect-server/device_connect_server/portal/templates/coding_agents/_token_secret.html
+++ b/packages/device-connect-server/device_connect_server/portal/templates/coding_agents/_token_secret.html
@@ -1,0 +1,22 @@
+<div class="rounded-lg bg-amber-50 border border-amber-300 p-4 mt-2">
+  <div class="flex items-start gap-2 mb-3">
+    <svg class="w-5 h-5 text-amber-600 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M5 19h14a2 2 0 001.84-2.75L13.74 4a2 2 0 00-3.48 0L3.16 16.25A2 2 0 005 19z"/></svg>
+    <div>
+      <p class="text-sm font-semibold text-amber-900">Copy this token now — it won't be shown again.</p>
+      <p class="text-xs text-amber-800 mt-0.5">
+        We only store its hash. If you lose it, mint a new one and revoke this.
+      </p>
+    </div>
+  </div>
+  <div class="flex items-center gap-2">
+    <code id="new-token-value"
+          class="flex-1 bg-gray-900 text-gray-100 rounded-lg px-3 py-2 text-xs font-mono break-all">{{ record.token }}</code>
+    <button type="button"
+            onclick="navigator.clipboard.writeText(document.getElementById('new-token-value').textContent);this.textContent='Copied';setTimeout(()=>{this.textContent='Copy';},1500);"
+            class="px-3 py-2 bg-white border border-gray-300 text-gray-700 text-xs font-medium rounded-lg hover:bg-gray-50">Copy</button>
+  </div>
+  <p class="text-xs text-amber-800 mt-3">
+    Use it as <code class="bg-amber-100 px-1 rounded">Authorization: Bearer {{ record.token }}</code>
+    or set <code class="bg-amber-100 px-1 rounded">DEVICE_CONNECT_PORTAL_TOKEN</code>.
+  </p>
+</div>

--- a/packages/device-connect-server/device_connect_server/portal/templates/coding_agents/_tokens_table.html
+++ b/packages/device-connect-server/device_connect_server/portal/templates/coding_agents/_tokens_table.html
@@ -1,0 +1,53 @@
+{% if not tokens %}
+<div class="px-5 py-8 text-center text-sm text-gray-400">
+  No tokens yet. Create one above, or run <code class="bg-gray-100 px-1 rounded">dc-portalctl auth login</code>.
+</div>
+{% else %}
+<table class="w-full text-sm">
+  <thead class="text-xs uppercase text-gray-500 bg-gray-50 border-b border-gray-200">
+    <tr>
+      <th class="text-left px-5 py-2 font-medium">Label</th>
+      <th class="text-left px-5 py-2 font-medium">Token id</th>
+      <th class="text-left px-5 py-2 font-medium">Scopes</th>
+      <th class="text-left px-5 py-2 font-medium">Created</th>
+      <th class="text-left px-5 py-2 font-medium">Status</th>
+      <th class="text-right px-5 py-2 font-medium"></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for t in tokens %}
+    <tr class="border-b border-gray-100 {% if t.revoked %}bg-gray-50 text-gray-400{% endif %}">
+      <td class="px-5 py-3">{{ (t.label or '-')|e }}</td>
+      <td class="px-5 py-3"><code class="text-xs">dcp_{{ t.token_id }}_…</code></td>
+      <td class="px-5 py-3">
+        <div class="flex flex-wrap gap-1">
+          {% for s in t.scopes %}
+          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium {% if t.revoked %}bg-gray-200 text-gray-500{% else %}bg-indigo-50 text-indigo-700{% endif %}">{{ s }}</span>
+          {% endfor %}
+        </div>
+      </td>
+      <td class="px-5 py-3 text-xs text-gray-500">{{ t.created_at }}</td>
+      <td class="px-5 py-3">
+        {% if t.revoked %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-200 text-gray-600">revoked</span>
+        {% else %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">active</span>
+        {% endif %}
+      </td>
+      <td class="px-5 py-3 text-right">
+        {% if not t.revoked %}
+        <button type="button"
+                hx-post="/coding-agents/tokens/{{ t.token_id }}/revoke"
+                hx-target="#tokens-table"
+                hx-swap="innerHTML"
+                hx-confirm="Revoke this token? Any agent or CI job using it will get 401 immediately."
+                class="text-sm text-red-600 hover:text-red-700 font-medium">
+          Revoke
+        </button>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}

--- a/packages/device-connect-server/device_connect_server/portal/templates/coding_agents/page.html
+++ b/packages/device-connect-server/device_connect_server/portal/templates/coding_agents/page.html
@@ -1,0 +1,128 @@
+{% extends "base.html" %}
+{% block title %}Coding Agents{% endblock %}
+{% block content %}
+<div class="mb-8">
+  <h1 class="text-2xl font-bold text-gray-900">Coding Agents</h1>
+  <p class="text-sm text-gray-500 mt-1">
+    Hand off this fleet to a coding agent (Claude Code, Codex, Cursor, …) in two steps.
+    Tenant <code class="bg-gray-100 px-1.5 py-0.5 rounded text-indigo-700">{{ tenant }}</code>.
+  </p>
+</div>
+
+<!-- Step 1: download + hand-off -->
+<div class="bg-white rounded-xl border border-gray-200 p-6 mb-6">
+  <div class="flex items-start justify-between gap-4 flex-wrap mb-4">
+    <div>
+      <h2 class="text-lg font-semibold text-gray-900 mb-1">1. Download AGENTS.md and drop it in your repo</h2>
+      <p class="text-sm text-gray-500 max-w-2xl">
+        A single Markdown playbook, rendered for tenant
+        <code class="bg-gray-100 px-1.5 py-0.5 rounded text-indigo-700">{{ tenant }}</code>
+        with your portal URL and NATS host pre-filled. The agent creates its own venv at
+        <code class="bg-gray-100 px-1 rounded">~/.dc-portalctl/venv</code>, installs the
+        CLI, runs <code class="bg-gray-100 px-1 rounded">auth login</code> (one browser
+        approval), and follows the playbook for provisioning, launching (local + SSH),
+        discovery, invocation, and event streaming.
+      </p>
+    </div>
+    <a href="/coding-agents/AGENTS.md"
+       class="shrink-0 inline-flex items-center px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors">
+      <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+      Download AGENTS.md
+    </a>
+  </div>
+</div>
+
+<!-- Step 2: hand-off prompt -->
+<div class="bg-white rounded-xl border border-gray-200 p-6 mb-6">
+  <h2 class="text-lg font-semibold text-gray-900 mb-1">2. Tell your agent</h2>
+  <p class="text-sm text-gray-500 mb-3">
+    Paste this into your agent. It will install the CLI, prompt you once to approve
+    in the browser, then take it from there. No manual setup on your side.
+  </p>
+  <div class="relative">
+<pre id="handoff-prompt" class="bg-gray-900 text-gray-100 rounded-lg px-4 py-3 text-xs overflow-x-auto whitespace-pre-wrap"><code>Read AGENTS.md in this repo. It describes a Device Connect fleet on tenant {{ tenant }} at {{ portal_url }}.
+Set up the dc-portalctl CLI per the playbook (install + auth login), then list the devices.</code></pre>
+    <button type="button"
+            onclick="navigator.clipboard.writeText(document.getElementById('handoff-prompt').textContent);this.textContent='Copied';setTimeout(()=>{this.textContent='Copy';},1500);"
+            class="absolute top-2 right-2 px-2 py-1 bg-white/10 hover:bg-white/20 text-gray-100 text-xs font-medium rounded">Copy</button>
+  </div>
+  <p class="text-xs text-gray-500 mt-3">
+    The browser approval is the one human-in-the-loop step — you'll see a verification
+    page from <code class="bg-gray-100 px-1 rounded">dc-portalctl auth login</code> at
+    <code class="bg-gray-100 px-1 rounded">{{ portal_url }}/auth/cli/&lt;id&gt;</code>.
+    Click Approve and the agent is authorized.
+  </p>
+</div>
+
+<!-- API tokens (advanced / fallback) -->
+<details open class="bg-white rounded-xl border border-gray-200">
+  <summary class="px-5 py-4 cursor-pointer flex items-center justify-between hover:bg-gray-50 rounded-xl">
+    <div>
+      <h2 class="text-lg font-semibold text-gray-900">API tokens (advanced)</h2>
+      <p class="text-xs text-gray-500 mt-0.5">
+        For agents that can't run <code class="bg-gray-100 px-1 rounded">dc-portalctl auth login</code> —
+        e.g. Cursor MCP servers, GitHub Actions, sandboxes without a browser. Mint a token
+        here and set it as <code class="bg-gray-100 px-1 rounded">DEVICE_CONNECT_PORTAL_TOKEN</code>.
+      </p>
+    </div>
+    <svg class="w-5 h-5 text-gray-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+  </summary>
+
+  <div class="border-t border-gray-200">
+    <div class="px-5 py-4 flex items-center justify-end">
+      <button type="button"
+              onclick="document.getElementById('mint-form').classList.toggle('hidden')"
+              class="inline-flex items-center px-3 py-1.5 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700">
+        <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
+        Create token
+      </button>
+    </div>
+
+    <!-- Mint form (collapsed by default) -->
+    <div id="mint-form" class="hidden px-5 py-4 border-t border-gray-200 bg-gray-50">
+      <form hx-post="/coding-agents/tokens"
+            hx-target="#mint-result"
+            hx-swap="innerHTML"
+            hx-on::after-request="if(event.detail.successful){this.reset();htmx.trigger('body','refresh-tokens');}"
+            class="space-y-3">
+        <div>
+          <label class="block text-xs font-medium text-gray-700 mb-1" for="token-label">Label</label>
+          <input id="token-label" type="text" name="label" maxlength="80"
+                 placeholder="e.g. cursor-laptop, ci-bot"
+                 class="w-full rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500">
+        </div>
+        <div>
+          <span class="block text-xs font-medium text-gray-700 mb-1">Scopes</span>
+          <div class="grid grid-cols-2 md:grid-cols-3 gap-2">
+            {% for scope in allowed_scopes %}
+            <label class="inline-flex items-center text-sm text-gray-700 bg-white border border-gray-200 rounded-lg px-3 py-1.5">
+              <input type="checkbox" name="scopes" value="{{ scope }}"
+                     {% if scope in default_scopes %}checked{% endif %}
+                     class="mr-2 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+              <code class="text-xs">{{ scope }}</code>
+            </label>
+            {% endfor %}
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <button type="submit"
+                  class="inline-flex items-center px-3 py-1.5 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700">
+            Mint token
+          </button>
+          <button type="button"
+                  onclick="document.getElementById('mint-form').classList.add('hidden')"
+                  class="text-sm text-gray-500 hover:text-gray-700">Cancel</button>
+        </div>
+        <div id="mint-result"></div>
+      </form>
+    </div>
+
+    <!-- Tokens table -->
+    <div id="tokens-table"
+         hx-get="/coding-agents/tokens"
+         hx-trigger="refresh-tokens from:body">
+      {% include "coding_agents/_tokens_table.html" %}
+    </div>
+  </div>
+</details>
+{% endblock %}

--- a/packages/device-connect-server/device_connect_server/portal/templates/login.html
+++ b/packages/device-connect-server/device_connect_server/portal/templates/login.html
@@ -30,6 +30,7 @@
 
       <form method="POST" action="/login"
             hx-post="/login" hx-target="#error-msg" hx-swap="innerHTML">
+        {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
         <div class="space-y-4">
           <div>
             <label for="username" class="block text-sm font-medium text-gray-700 mb-1">Username</label>

--- a/packages/device-connect-server/device_connect_server/portal/views/agent_api.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/agent_api.py
@@ -1,0 +1,806 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agent API — JSON-only, Bearer-token authenticated namespace at /api/agent/v1/*.
+
+Built for coding agents and CI clients. Distinct from the htmx browser views:
+
+- always JSON; never HTML, never redirects
+- per-token scopes (devices:read / :provision / :credentials / :invoke,
+  events:read, admin:tenants / admin:*)
+- read endpoints return whole sub-objects (status / identity / capabilities)
+  so the API doesn't drop fields the registry adds later
+- write endpoints return a stable {success, trace_id, result|error} envelope
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import secrets
+import time
+import uuid
+from typing import Any
+
+from aiohttp import web
+
+from .. import config
+from ..services import credentials as credentials_svc
+from ..services import registry_client, tokens as tokens_svc
+from ..services.backend import get_backend, validate_name
+
+logger = logging.getLogger(__name__)
+audit = logging.getLogger("device_connect.agent_api.audit")
+
+PREFIX = "/api/agent/v1"
+
+# Server-side hard caps for event streams. Apply regardless of what the client requests.
+MAX_STREAM_DURATION_S = 3600       # 1 hour
+MAX_STREAM_COUNT = 10_000
+
+
+def setup_routes(app: web.Application):
+    r = app.router
+    r.add_get(PREFIX + "/me", me)
+    r.add_get(PREFIX + "/fleet", fleet)
+    r.add_get(PREFIX + "/devices", devices_list)
+    r.add_post(PREFIX + "/devices", devices_provision)
+    r.add_get(PREFIX + "/devices/{device_id}", device_get)
+    r.add_delete(PREFIX + "/devices/{device_id}", device_delete)
+    r.add_get(PREFIX + "/devices/{device_id}/identity", device_identity)
+    r.add_get(PREFIX + "/devices/{device_id}/status", device_status)
+    r.add_get(PREFIX + "/devices/{device_id}/capabilities", device_capabilities)
+    r.add_get(PREFIX + "/devices/{device_id}/functions", device_functions)
+    r.add_get(PREFIX + "/devices/{device_id}/events", device_events)
+    r.add_get(PREFIX + "/devices/{device_id}/credentials", device_credentials_get)
+    r.add_post(PREFIX + "/devices/{device_id}/credentials:rotate", device_credentials_rotate)
+    r.add_post(PREFIX + "/devices/{device_id}/invoke", device_invoke)
+    r.add_post(PREFIX + "/invoke-with-fallback", invoke_with_fallback)
+    r.add_get(
+        PREFIX + "/devices/{device_id}/events/{event_name}/stream",
+        device_event_stream,
+    )
+
+
+# ── envelope helpers ────────────────────────────────────────────────
+
+
+def _trace_id() -> str:
+    return "trace-" + secrets.token_hex(8)
+
+
+def _ok(result: Any, *, status: int = 200, trace_id: str | None = None) -> web.Response:
+    return web.json_response(
+        {"success": True, "trace_id": trace_id or _trace_id(), "result": result},
+        status=status,
+    )
+
+
+def _err(
+    *,
+    status: int,
+    code: str,
+    message: str,
+    trace_id: str | None = None,
+) -> web.Response:
+    return web.json_response(
+        {"success": False, "trace_id": trace_id or _trace_id(),
+         "error": {"code": code, "message": message}},
+        status=status,
+    )
+
+
+def _require_scope(request: web.Request, scope: str) -> tuple[dict, web.Response | None]:
+    record = request.get("token") or {}
+    if not tokens_svc.has_scope(record, scope):
+        return record, _err(status=403, code="missing_scope",
+                            message=f"Token does not carry required scope: {scope}")
+    return record, None
+
+
+def _resolve_tenant(request: web.Request) -> tuple[str, web.Response | None]:
+    """Resolve tenant: ?tenant= override requires admin role + admin:tenants/admin:*."""
+    record = request.get("token") or {}
+    user = request["user"]
+    override = request.query.get("tenant")
+    if override:
+        if user.get("role") != "admin" or not (
+            tokens_svc.has_scope(record, "admin:tenants") or tokens_svc.has_scope(record, "admin:*")
+        ):
+            return "", _err(status=403, code="tenant_override_forbidden",
+                            message="tenant override requires admin role and admin scope")
+        try:
+            validate_name(override, "tenant")
+        except ValueError as e:
+            return "", _err(status=400, code="invalid_tenant", message=str(e))
+        return override, None
+    return user["tenant"], None
+
+
+def _full_device_name(tenant: str, device_id: str) -> str:
+    """Match the existing devices.create_device convention: tenant-prefixed, unless
+    the caller already passed a fully-qualified id."""
+    if device_id.startswith(f"{tenant}-"):
+        return device_id
+    return f"{tenant}-{device_id}"
+
+
+def _audit(request: web.Request, action: str, **fields):
+    record = request.get("token") or {}
+    audit.info(
+        "agent_api action=%s token_id=%s username=%s tenant=%s ip=%s ua=%s %s",
+        action,
+        record.get("token_id", "?"),
+        record.get("username", "?"),
+        record.get("tenant", "?"),
+        request.remote or "?",
+        request.headers.get("User-Agent", "?"),
+        " ".join(f"{k}={v}" for k, v in fields.items()),
+    )
+
+
+# ── /me, /fleet ─────────────────────────────────────────────────────
+
+
+async def me(request: web.Request) -> web.Response:
+    record = request.get("token") or {}
+    return web.json_response({
+        "username": record.get("username"),
+        "tenant": record.get("tenant"),
+        "role": record.get("role"),
+        "scopes": record.get("scopes", []),
+        "token_id": record.get("token_id"),
+    })
+
+
+async def fleet(request: web.Request) -> web.Response:
+    _, err = _require_scope(request, "devices:read")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    try:
+        live = registry_client.list_live_devices(tenant)
+    except Exception as e:
+        logger.warning("fleet: registry query failed: %s", e)
+        live = []
+
+    creds = credentials_svc.list_credentials(tenant=tenant)
+    by_type: dict[str, int] = {}
+    for d in live:
+        dt = d.get("device_type") or "unknown"
+        by_type[dt] = by_type.get(dt, 0) + 1
+    online = sum(1 for d in live if d.get("status") == "available")
+
+    return web.json_response({
+        "tenant": tenant,
+        "devices_registered": len(live),
+        "devices_online": online,
+        "credentials_issued": len(creds),
+        "by_device_type": by_type,
+    })
+
+
+# ── /devices read surface ───────────────────────────────────────────
+
+
+def _paginate(items: list, request: web.Request) -> dict:
+    try:
+        offset = max(0, int(request.query.get("offset", "0")))
+    except ValueError:
+        offset = 0
+    try:
+        limit = int(request.query.get("limit", "200"))
+    except ValueError:
+        limit = 200
+    limit = max(1, min(limit, 1000))
+
+    page = items[offset: offset + limit]
+    next_offset = offset + len(page) if (offset + len(page)) < len(items) else None
+    return {
+        "matched": len(items),
+        "returned": len(page),
+        "offset": offset,
+        "next_offset": next_offset,
+        "results": page,
+    }
+
+
+def _device_doc(tenant: str, device_id: str) -> dict | None:
+    """Look up a device record. Tries the id as given, then with the tenant prefix."""
+    doc = registry_client.get_device(tenant, device_id)
+    if doc:
+        return doc
+    full = _full_device_name(tenant, device_id)
+    if full != device_id:
+        return registry_client.get_device(tenant, full)
+    return None
+
+
+async def devices_list(request: web.Request) -> web.Response:
+    _, err = _require_scope(request, "devices:read")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    try:
+        live = registry_client.list_live_devices(tenant)
+    except Exception as e:
+        logger.warning("devices_list: registry query failed: %s", e)
+        live = []
+
+    results = [d.get("_raw", d) for d in live]
+    return web.json_response(_paginate(results, request))
+
+
+async def device_get(request: web.Request) -> web.Response:
+    _, err = _require_scope(request, "devices:read")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    device_id = request.match_info["device_id"]
+    doc = _device_doc(tenant, device_id)
+    if not doc:
+        return _err(status=404, code="not_found", message=f"Device not found: {device_id}")
+    return web.json_response(doc)
+
+
+async def device_identity(request: web.Request) -> web.Response:
+    _, err = _require_scope(request, "devices:read")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    device_id = request.match_info["device_id"]
+    doc = _device_doc(tenant, device_id)
+    if not doc:
+        return _err(status=404, code="not_found", message=f"Device not found: {device_id}")
+
+    # Whole identity sub-object, verbatim — see plan: never project to a single field.
+    return web.json_response({
+        "device_id": doc.get("device_id", device_id),
+        "identity": doc.get("identity") or {},
+    })
+
+
+async def device_status(request: web.Request) -> web.Response:
+    _, err = _require_scope(request, "devices:read")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    device_id = request.match_info["device_id"]
+    doc = _device_doc(tenant, device_id)
+    if not doc:
+        return _err(status=404, code="not_found", message=f"Device not found: {device_id}")
+
+    # Whole status sub-object, byte-equal with registry doc — agents must see every field.
+    return web.json_response({
+        "device_id": doc.get("device_id", device_id),
+        "status": doc.get("status") or {},
+    })
+
+
+async def device_capabilities(request: web.Request) -> web.Response:
+    _, err = _require_scope(request, "devices:read")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    device_id = request.match_info["device_id"]
+    doc = _device_doc(tenant, device_id)
+    if not doc:
+        return _err(status=404, code="not_found", message=f"Device not found: {device_id}")
+
+    caps = doc.get("capabilities") or {}
+    if not isinstance(caps, dict):
+        # Some older registry rows used a list — coerce to the canonical shape.
+        caps = {"description": "", "functions": [], "events": []}
+    caps.setdefault("description", "")
+    caps.setdefault("functions", [])
+    caps.setdefault("events", [])
+
+    return web.json_response({"device_id": doc.get("device_id", device_id), "capabilities": caps})
+
+
+async def device_functions(request: web.Request) -> web.Response:
+    """Convenience projection: byte-equal with capabilities.functions."""
+    _, err = _require_scope(request, "devices:read")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    device_id = request.match_info["device_id"]
+    doc = _device_doc(tenant, device_id)
+    if not doc:
+        return _err(status=404, code="not_found", message=f"Device not found: {device_id}")
+    caps = doc.get("capabilities") or {}
+    funcs = caps.get("functions", []) if isinstance(caps, dict) else []
+    return web.json_response({"device_id": doc.get("device_id", device_id), "functions": funcs})
+
+
+async def device_events(request: web.Request) -> web.Response:
+    """Convenience projection: byte-equal with capabilities.events."""
+    _, err = _require_scope(request, "devices:read")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    device_id = request.match_info["device_id"]
+    doc = _device_doc(tenant, device_id)
+    if not doc:
+        return _err(status=404, code="not_found", message=f"Device not found: {device_id}")
+    caps = doc.get("capabilities") or {}
+    events = caps.get("events", []) if isinstance(caps, dict) else []
+    return web.json_response({"device_id": doc.get("device_id", device_id), "events": events})
+
+
+# ── provisioning ────────────────────────────────────────────────────
+
+
+async def devices_provision(request: web.Request) -> web.Response:
+    """Create a new device + return its credentials inline in one call.
+
+    Body: {"device_name": str, "device_type"?, "location"?, "description"?, "metadata"?}
+    Returns 201 with {device, credentials: {filename, content}}.
+    """
+    trace = _trace_id()
+    _, err = _require_scope(request, "devices:provision")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return _err(status=400, code="invalid_json", message="Request body must be JSON",
+                    trace_id=trace)
+
+    device_name = (body.get("device_name") or "").strip()
+    if not device_name:
+        return _err(status=400, code="missing_device_name",
+                    message="device_name is required", trace_id=trace)
+
+    full_name = _full_device_name(tenant, device_name)
+    try:
+        validate_name(full_name, "device name")
+    except ValueError as e:
+        return _err(status=400, code="invalid_device_name", message=str(e), trace_id=trace)
+
+    backend = get_backend()
+    if not backend.is_bootstrapped():
+        return _err(status=503, code="not_bootstrapped",
+                    message="System not bootstrapped — admin must run setup first",
+                    trace_id=trace)
+
+    try:
+        broker_info = backend.broker_display_info()
+        await backend.add_device(
+            tenant, full_name,
+            host=broker_info["host"], port=broker_info["port"],
+        )
+        await backend.reload_broker()
+    except Exception as e:
+        logger.exception("provision failed for %s/%s", tenant, full_name)
+        return _err(status=500, code="provision_failed",
+                    message=f"Failed to create device: {e}", trace_id=trace)
+
+    filename = f"{full_name}.creds.json"
+    cred_data = credentials_svc.get_credential_data(filename) or {}
+
+    device_record = {
+        "device_id": full_name,
+        "tenant": tenant,
+        "identity": {
+            "device_type": body.get("device_type") or "",
+            "description": body.get("description") or "",
+        },
+        "status": {"location": body.get("location") or "", "availability": "unknown"},
+        "metadata": body.get("metadata") or {},
+    }
+
+    _audit(request, "provision", trace_id=trace, device_id=full_name)
+    return _ok(
+        {"device": device_record,
+         "credentials": {"filename": filename, "content": cred_data}},
+        status=201,
+        trace_id=trace,
+    )
+
+
+async def device_credentials_get(request: web.Request) -> web.Response:
+    """Re-download a device's credential file as inline JSON."""
+    trace = _trace_id()
+    _, err = _require_scope(request, "devices:credentials")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    device_id = request.match_info["device_id"]
+    full_name = _full_device_name(tenant, device_id)
+    filename = f"{full_name}.creds.json"
+    cred = credentials_svc.get_credential_data(filename)
+    if not cred:
+        # Try the id as given (admin-style absolute lookup)
+        cred = credentials_svc.get_credential_data(f"{device_id}.creds.json")
+        if cred:
+            full_name = device_id
+            filename = f"{device_id}.creds.json"
+    if not cred:
+        return _err(status=404, code="not_found",
+                    message=f"Credential file not found for {device_id}", trace_id=trace)
+
+    # Tenant binding check (admins with admin scope have already been allowed via override)
+    record = request.get("token") or {}
+    user = request["user"]
+    if cred.get("tenant") and cred.get("tenant") != user["tenant"]:
+        if user.get("role") != "admin" or not (
+            tokens_svc.has_scope(record, "admin:tenants") or tokens_svc.has_scope(record, "admin:*")
+        ):
+            return _err(status=403, code="tenant_mismatch",
+                        message="Credential belongs to another tenant", trace_id=trace)
+
+    _audit(request, "credentials_get", trace_id=trace, device_id=full_name)
+    return _ok({"filename": filename, "content": cred}, trace_id=trace)
+
+
+async def device_credentials_rotate(request: web.Request) -> web.Response:
+    """Rotate a device's credentials. Implementation defers to the active backend.
+
+    Phase-2 scope is to expose the endpoint with strong audit + scope enforcement.
+    Backends that don't yet implement rotation surface a clear 501.
+    """
+    trace = _trace_id()
+    _, err = _require_scope(request, "devices:credentials")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    device_id = request.match_info["device_id"]
+    full_name = _full_device_name(tenant, device_id)
+
+    backend = get_backend()
+    rotate = getattr(backend, "rotate_device_credentials", None)
+    if rotate is None:
+        return _err(status=501, code="not_implemented",
+                    message=f"Credential rotation not yet supported on the {backend.backend_name()} backend",
+                    trace_id=trace)
+
+    try:
+        await rotate(tenant, full_name)
+    except Exception as e:
+        logger.exception("rotate failed for %s/%s", tenant, full_name)
+        return _err(status=500, code="rotate_failed", message=str(e), trace_id=trace)
+
+    filename = f"{full_name}.creds.json"
+    cred_data = credentials_svc.get_credential_data(filename) or {}
+    _audit(request, "credentials_rotate", trace_id=trace, device_id=full_name)
+    return _ok({"filename": filename, "content": cred_data}, trace_id=trace)
+
+
+async def device_delete(request: web.Request) -> web.Response:
+    """Decommission a device. Requires devices:provision."""
+    trace = _trace_id()
+    _, err = _require_scope(request, "devices:provision")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    device_id = request.match_info["device_id"]
+    full_name = _full_device_name(tenant, device_id)
+
+    backend = get_backend()
+    remove = getattr(backend, "remove_device", None)
+    if remove is None:
+        return _err(status=501, code="not_implemented",
+                    message=f"Device removal not yet supported on the {backend.backend_name()} backend",
+                    trace_id=trace)
+    try:
+        await remove(tenant, full_name)
+    except Exception as e:
+        logger.exception("delete failed for %s/%s", tenant, full_name)
+        return _err(status=500, code="delete_failed", message=str(e), trace_id=trace)
+
+    _audit(request, "delete", trace_id=trace, device_id=full_name)
+    return _ok({"device_id": full_name, "deleted": True}, trace_id=trace)
+
+
+# ── invocation ──────────────────────────────────────────────────────
+
+
+def _truncate(s: str, n: int = 200) -> str:
+    if not isinstance(s, str):
+        return ""
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+async def device_invoke(request: web.Request) -> web.Response:
+    """Invoke an RPC on a single device.
+
+    Body: {"function": str, "params"?: dict, "reason"?: str, "timeout"?: float}
+    """
+    trace = _trace_id()
+    _, err = _require_scope(request, "devices:invoke")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    device_id = request.match_info["device_id"]
+    full_name = _full_device_name(tenant, device_id)
+
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return _err(status=400, code="invalid_json", message="Request body must be JSON",
+                    trace_id=trace)
+
+    function = (body.get("function") or "").strip()
+    if not function:
+        return _err(status=400, code="missing_function", message="function is required",
+                    trace_id=trace)
+
+    params = body.get("params") or {}
+    if not isinstance(params, dict):
+        return _err(status=400, code="invalid_params", message="params must be an object",
+                    trace_id=trace)
+    timeout = float(body.get("timeout") or 5.0)
+    reason = _truncate(body.get("reason") or body.get("llm_reasoning") or "", 500)
+
+    backend = get_backend()
+    started = time.monotonic()
+    try:
+        result = await backend.rpc_invoke(tenant, full_name, function, params, timeout=timeout)
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+        _audit(request, "invoke", trace_id=trace, device_id=full_name,
+               function=function, elapsed_ms=elapsed_ms, success=True,
+               reason=_truncate(reason, 120))
+        return _ok({"device_id": full_name, "function": function,
+                    "elapsed_ms": elapsed_ms, "response": result},
+                   trace_id=trace)
+    except Exception as e:
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+        _audit(request, "invoke", trace_id=trace, device_id=full_name,
+               function=function, elapsed_ms=elapsed_ms, success=False,
+               reason=_truncate(reason, 120), error=str(e))
+        return _err(status=502, code="invoke_failed", message=str(e), trace_id=trace)
+
+
+async def invoke_with_fallback(request: web.Request) -> web.Response:
+    """Try a list of devices in order; return the first success + per-device failures.
+
+    Body: {"device_ids": [str, ...], "function": str, "params"?, "reason"?, "timeout"?}
+    """
+    trace = _trace_id()
+    _, err = _require_scope(request, "devices:invoke")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return _err(status=400, code="invalid_json", message="Request body must be JSON",
+                    trace_id=trace)
+
+    ids = body.get("device_ids") or []
+    if not isinstance(ids, list) or not ids:
+        return _err(status=400, code="missing_device_ids",
+                    message="device_ids must be a non-empty list", trace_id=trace)
+    function = (body.get("function") or "").strip()
+    if not function:
+        return _err(status=400, code="missing_function", message="function is required",
+                    trace_id=trace)
+    params = body.get("params") or {}
+    timeout = float(body.get("timeout") or 5.0)
+    reason = _truncate(body.get("reason") or body.get("llm_reasoning") or "", 500)
+
+    backend = get_backend()
+    failures = []
+    for raw_id in ids:
+        full_name = _full_device_name(tenant, raw_id)
+        started = time.monotonic()
+        try:
+            response = await backend.rpc_invoke(tenant, full_name, function, params, timeout=timeout)
+            elapsed_ms = int((time.monotonic() - started) * 1000)
+            _audit(request, "invoke_fallback", trace_id=trace, device_id=full_name,
+                   function=function, elapsed_ms=elapsed_ms, success=True,
+                   reason=_truncate(reason, 120))
+            return _ok(
+                {"device_id": full_name, "function": function,
+                 "elapsed_ms": elapsed_ms, "response": response,
+                 "tried": [{"device_id": _full_device_name(tenant, x), "ok": (x == raw_id)}
+                           for x in ids[: ids.index(raw_id) + 1]],
+                 "failures": failures},
+                trace_id=trace,
+            )
+        except Exception as e:
+            failures.append({"device_id": full_name, "error": str(e)})
+
+    _audit(request, "invoke_fallback", trace_id=trace, function=function, success=False,
+           reason=_truncate(reason, 120))
+    return _err(status=502, code="all_failed",
+                message="All fallback devices failed", trace_id=trace)
+
+
+# ── event streaming (bounded) ──────────────────────────────────────
+
+
+def _parse_bool(v: str | None) -> bool:
+    return (v or "").lower() in ("1", "true", "yes", "y")
+
+
+async def device_event_stream(request: web.Request) -> web.Response:
+    """Bounded event stream.
+
+    Query params:
+      format:   "ndjson" (default) | "sse"
+      duration: max wall-clock seconds before close (>=1, server caps at MAX_STREAM_DURATION_S)
+      count:    max events delivered before close (>=1, server caps at MAX_STREAM_COUNT)
+      follow:   true to allow unbounded; at least one of duration/count/follow MUST be set
+
+    NDJSON output emits a final "_meta" line with closed_by/events_received/elapsed_s.
+    """
+    _, err = _require_scope(request, "events:read")
+    if err:
+        return err
+    tenant, err = _resolve_tenant(request)
+    if err:
+        return err
+
+    device_id = request.match_info["device_id"]
+    event_name = request.match_info["event_name"]
+    full_name = _full_device_name(tenant, device_id)
+
+    fmt = (request.query.get("format") or "ndjson").lower()
+    if fmt not in ("ndjson", "sse"):
+        return _err(status=400, code="invalid_format",
+                    message="format must be 'ndjson' or 'sse'")
+
+    follow = _parse_bool(request.query.get("follow"))
+    duration_raw = request.query.get("duration")
+    count_raw = request.query.get("count")
+
+    if duration_raw is None and count_raw is None and not follow:
+        return _err(status=400, code="missing_bound",
+                    message="at least one of duration, count, or follow must be supplied")
+
+    try:
+        duration = float(duration_raw) if duration_raw is not None else None
+        count = int(count_raw) if count_raw is not None else None
+    except ValueError:
+        return _err(status=400, code="invalid_bound",
+                    message="duration must be a number; count must be an integer")
+
+    if duration is not None:
+        if duration <= 0:
+            return _err(status=400, code="invalid_bound", message="duration must be > 0")
+        duration = min(duration, float(MAX_STREAM_DURATION_S))
+    if count is not None:
+        if count <= 0:
+            return _err(status=400, code="invalid_bound", message="count must be > 0")
+        count = min(count, MAX_STREAM_COUNT)
+    # Server hard cap even on follow=true:
+    if duration is None and count is None:
+        duration = float(MAX_STREAM_DURATION_S)
+        count = MAX_STREAM_COUNT
+
+    headers = {"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"}
+    if fmt == "sse":
+        headers["Content-Type"] = "text/event-stream"
+    else:
+        headers["Content-Type"] = "application/x-ndjson"
+
+    response = web.StreamResponse(headers=headers)
+    await response.prepare(request)
+
+    backend = get_backend()
+    client = None
+    sub = None
+    started = time.monotonic()
+    received = 0
+    closed_by = "server"
+
+    try:
+        client = await backend.rpc_connect()
+        subject = f"device-connect.{tenant}.{full_name}.event.{event_name}"
+        queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+
+        async def _on_msg_generic(msg_data, _subject=None):
+            await queue.put(msg_data)
+
+        if backend.backend_name() == "nats":
+            async def _nats_cb(msg):
+                await queue.put(msg.data)
+            sub = await backend.subscribe_events(client, subject, _nats_cb)
+        else:
+            sub = await backend.subscribe_events(client, subject, _on_msg_generic)
+
+        if fmt == "sse":
+            await response.write(b": connected\n\n")
+
+        while True:
+            elapsed = time.monotonic() - started
+            if duration is not None and elapsed >= duration:
+                closed_by = "duration"
+                break
+            if count is not None and received >= count:
+                closed_by = "count"
+                break
+
+            wait_for = 15.0
+            if duration is not None:
+                wait_for = max(0.1, min(wait_for, duration - elapsed))
+
+            try:
+                raw = await asyncio.wait_for(queue.get(), timeout=wait_for)
+            except asyncio.TimeoutError:
+                if fmt == "sse":
+                    await response.write(b": keepalive\n\n")
+                continue
+
+            try:
+                payload = json.loads(raw if isinstance(raw, (str, bytes)) else raw)
+            except (json.JSONDecodeError, TypeError):
+                payload = {"raw": raw.decode(errors="replace") if isinstance(raw, bytes) else str(raw)}
+
+            event = {
+                "device_id": full_name,
+                "event": event_name,
+                "ts": time.time(),
+                "params": payload.get("params", payload),
+            }
+            received += 1
+            if fmt == "sse":
+                await response.write(f"data: {json.dumps(event)}\n\n".encode())
+            else:
+                await response.write((json.dumps(event) + "\n").encode())
+    except (ConnectionResetError, asyncio.CancelledError):
+        closed_by = "client_disconnect"
+    finally:
+        try:
+            if client is not None:
+                await backend.unsubscribe_events(client, sub)
+        except Exception:
+            logger.debug("unsubscribe_events failed", exc_info=True)
+        elapsed = time.monotonic() - started
+        if fmt == "ndjson":
+            try:
+                trailer = {"_meta": {"closed_by": closed_by,
+                                     "events_received": received,
+                                     "elapsed_s": round(elapsed, 3)}}
+                await response.write((json.dumps(trailer) + "\n").encode())
+            except (ConnectionResetError, asyncio.CancelledError):
+                pass
+
+    return response

--- a/packages/device-connect-server/device_connect_server/portal/views/agent_api.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/agent_api.py
@@ -27,6 +27,7 @@ from typing import Any
 from aiohttp import web
 
 from .. import config
+from ..services import cli_auth as cli_auth_svc
 from ..services import credentials as credentials_svc
 from ..services import registry_client, tokens as tokens_svc
 from ..services.backend import get_backend, validate_name
@@ -43,6 +44,10 @@ MAX_STREAM_COUNT = 10_000
 
 def setup_routes(app: web.Application):
     r = app.router
+    # Public CLI-auth endpoints (exempt from Bearer middleware in app.py).
+    r.add_post(PREFIX + "/auth/cli/init", auth_cli_init)
+    r.add_post(PREFIX + "/auth/cli/poll", auth_cli_poll)
+
     r.add_get(PREFIX + "/me", me)
     r.add_get(PREFIX + "/fleet", fleet)
     r.add_get(PREFIX + "/devices", devices_list)
@@ -139,6 +144,58 @@ def _audit(request: web.Request, action: str, **fields):
         request.headers.get("User-Agent", "?"),
         " ".join(f"{k}={v}" for k, v in fields.items()),
     )
+
+
+# ── public CLI-auth init/poll ───────────────────────────────────────
+
+
+def _verification_url(request: web.Request, request_id: str) -> str:
+    scheme = request.headers.get("X-Forwarded-Proto", request.url.scheme)
+    host = request.headers.get("X-Forwarded-Host", request.host)
+    return f"{scheme}://{host}/auth/cli/{request_id}"
+
+
+async def auth_cli_init(request: web.Request) -> web.Response:
+    """Public: start a CLI-auth flow. Returns a request_id and verification URL."""
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return _err(status=400, code="invalid_json", message="Request body must be JSON")
+    scopes = body.get("scopes") or []
+    label = (body.get("label") or "").strip()[:64]
+    if not isinstance(scopes, list) or not scopes:
+        return _err(status=400, code="missing_scopes",
+                    message="scopes must be a non-empty list")
+    try:
+        rec = cli_auth_svc.init(scopes_requested=list(scopes), label=label)
+    except cli_auth_svc.CliAuthError as e:
+        return _err(status=400, code="invalid_request", message=str(e))
+    rec["verification_url"] = _verification_url(request, rec["request_id"])
+    return web.json_response(rec)
+
+
+async def auth_cli_poll(request: web.Request) -> web.Response:
+    """Public: poll a pending CLI-auth flow.
+
+    Returns:
+      200 + token on approved (record consumed)
+      202 on pending
+      410 on denied / expired / not_found
+    """
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return _err(status=400, code="invalid_json", message="Request body must be JSON")
+    request_id = (body.get("request_id") or "").strip()
+    if not request_id:
+        return _err(status=400, code="missing_request_id", message="request_id is required")
+
+    status, payload = cli_auth_svc.consume_on_poll(request_id)
+    if status == "approved":
+        return web.json_response({"status": "approved", **(payload or {})})
+    if status == "pending":
+        return web.json_response({"status": "pending"}, status=202)
+    return web.json_response({"status": status}, status=410)
 
 
 # ── /me, /fleet ─────────────────────────────────────────────────────

--- a/packages/device-connect-server/device_connect_server/portal/views/agent_api.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/agent_api.py
@@ -21,12 +21,10 @@ import json
 import logging
 import secrets
 import time
-import uuid
 from typing import Any
 
 from aiohttp import web
 
-from .. import config
 from ..services import cli_auth as cli_auth_svc
 from ..services import credentials as credentials_svc
 from ..services import registry_client, tokens as tokens_svc
@@ -40,6 +38,19 @@ PREFIX = "/api/agent/v1"
 # Server-side hard caps for event streams. Apply regardless of what the client requests.
 MAX_STREAM_DURATION_S = 3600       # 1 hour
 MAX_STREAM_COUNT = 10_000
+# Server-side hard cap on per-RPC invoke timeout. A misbehaving client requesting
+# a multi-hour timeout could otherwise pin a backend connection.
+MAX_INVOKE_TIMEOUT_S = 60.0
+
+
+def _clamp_timeout(value: Any, default: float = 5.0) -> float:
+    try:
+        t = float(value) if value is not None else default
+    except (TypeError, ValueError):
+        t = default
+    if t <= 0:
+        t = default
+    return min(t, MAX_INVOKE_TIMEOUT_S)
 
 
 def setup_routes(app: web.Application):
@@ -500,8 +511,16 @@ async def device_credentials_get(request: web.Request) -> web.Response:
     full_name = _full_device_name(tenant, device_id)
     filename = f"{full_name}.creds.json"
     cred = credentials_svc.get_credential_data(filename)
-    if not cred:
-        # Try the id as given (admin-style absolute lookup)
+
+    record = request.get("token") or {}
+    user = request["user"]
+    is_admin = user.get("role") == "admin" and (
+        tokens_svc.has_scope(record, "admin:tenants") or tokens_svc.has_scope(record, "admin:*")
+    )
+
+    if not cred and is_admin:
+        # Admin absolute lookup: allow unprefixed filenames so admins can resolve
+        # legacy or cross-tenant credentials. Non-admins must never reach this branch.
         cred = credentials_svc.get_credential_data(f"{device_id}.creds.json")
         if cred:
             full_name = device_id
@@ -510,15 +529,12 @@ async def device_credentials_get(request: web.Request) -> web.Response:
         return _err(status=404, code="not_found",
                     message=f"Credential file not found for {device_id}", trace_id=trace)
 
-    # Tenant binding check (admins with admin scope have already been allowed via override)
-    record = request.get("token") or {}
-    user = request["user"]
-    if cred.get("tenant") and cred.get("tenant") != user["tenant"]:
-        if user.get("role") != "admin" or not (
-            tokens_svc.has_scope(record, "admin:tenants") or tokens_svc.has_scope(record, "admin:*")
-        ):
-            return _err(status=403, code="tenant_mismatch",
-                        message="Credential belongs to another tenant", trace_id=trace)
+    # Fail-closed tenant binding. A credential file without a `tenant` field is
+    # treated as untrusted for non-admins: we refuse rather than leak it.
+    cred_tenant = cred.get("tenant")
+    if not is_admin and cred_tenant != user["tenant"]:
+        return _err(status=403, code="tenant_mismatch",
+                    message="Credential belongs to another tenant", trace_id=trace)
 
     _audit(request, "credentials_get", trace_id=trace, device_id=full_name)
     return _ok({"filename": filename, "content": cred}, trace_id=trace)
@@ -629,7 +645,7 @@ async def device_invoke(request: web.Request) -> web.Response:
     if not isinstance(params, dict):
         return _err(status=400, code="invalid_params", message="params must be an object",
                     trace_id=trace)
-    timeout = float(body.get("timeout") or 5.0)
+    timeout = _clamp_timeout(body.get("timeout"))
     reason = _truncate(body.get("reason") or body.get("llm_reasoning") or "", 500)
 
     backend = get_backend()
@@ -679,12 +695,12 @@ async def invoke_with_fallback(request: web.Request) -> web.Response:
         return _err(status=400, code="missing_function", message="function is required",
                     trace_id=trace)
     params = body.get("params") or {}
-    timeout = float(body.get("timeout") or 5.0)
+    timeout = _clamp_timeout(body.get("timeout"))
     reason = _truncate(body.get("reason") or body.get("llm_reasoning") or "", 500)
 
     backend = get_backend()
     failures = []
-    for raw_id in ids:
+    for idx, raw_id in enumerate(ids):
         full_name = _full_device_name(tenant, raw_id)
         started = time.monotonic()
         try:
@@ -696,8 +712,8 @@ async def invoke_with_fallback(request: web.Request) -> web.Response:
             return _ok(
                 {"device_id": full_name, "function": function,
                  "elapsed_ms": elapsed_ms, "response": response,
-                 "tried": [{"device_id": _full_device_name(tenant, x), "ok": (x == raw_id)}
-                           for x in ids[: ids.index(raw_id) + 1]],
+                 "tried": [{"device_id": _full_device_name(tenant, x), "ok": (i == idx)}
+                           for i, x in enumerate(ids[: idx + 1])],
                  "failures": failures},
                 trace_id=trace,
             )
@@ -737,6 +753,10 @@ async def device_event_stream(request: web.Request) -> web.Response:
 
     device_id = request.match_info["device_id"]
     event_name = request.match_info["event_name"]
+    try:
+        validate_name(event_name, "event")
+    except ValueError as e:
+        return _err(status=400, code="invalid_event_name", message=str(e))
     full_name = _full_device_name(tenant, device_id)
 
     fmt = (request.query.get("format") or "ndjson").lower()

--- a/packages/device-connect-server/device_connect_server/portal/views/auth.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/auth.py
@@ -32,12 +32,24 @@ async def root_page(request: web.Request):
     raise web.HTTPFound("/login")
 
 
+def _safe_next(value: str | None) -> str | None:
+    """Accept only relative paths so an attacker can't bounce login to an external site."""
+    if not value:
+        return None
+    if not value.startswith("/") or value.startswith("//"):
+        return None
+    if "\n" in value or "\r" in value:
+        return None
+    return value
+
+
 async def login_page(request: web.Request):
     session = await _get_session(request)
+    next_url = _safe_next(request.query.get("next"))
     if session.get("username"):
-        target = "/admin" if session.get("role") == "admin" else "/dashboard"
+        target = next_url or ("/admin" if session.get("role") == "admin" else "/dashboard")
         raise web.HTTPFound(target)
-    return aiohttp_jinja2.render_template("login.html", request, {"error": None})
+    return aiohttp_jinja2.render_template("login.html", request, {"error": None, "next": next_url})
 
 
 async def login_submit(request: web.Request):
@@ -59,7 +71,8 @@ async def login_submit(request: web.Request):
         return aiohttp_jinja2.render_template("login.html", request, {"error": "Invalid username or password"})
 
     # Set session and redirect
-    redirect_url = "/admin" if user["role"] == "admin" else "/dashboard"
+    next_url = _safe_next(data.get("next"))
+    redirect_url = next_url or ("/admin" if user["role"] == "admin" else "/dashboard")
     if _is_htmx(request):
         response = web.Response(status=200)
         response.headers["HX-Redirect"] = redirect_url

--- a/packages/device-connect-server/device_connect_server/portal/views/cli_auth.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/cli_auth.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Browser-side CLI auth approval pages.
+
+The CLI hands the user a URL like /auth/cli/<request_id>. If the user is not
+logged in, the global auth middleware sends them to /login?next=<this URL>;
+once logged in they land on the approval page, click Approve, and the
+portal mints a token bound to their account that the CLI's poll receives.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiohttp_jinja2
+from aiohttp import web
+
+from ..services import cli_auth as cli_auth_svc
+
+logger = logging.getLogger(__name__)
+
+
+def setup_routes(app: web.Application):
+    app.router.add_get("/auth/cli/{request_id}", cli_approve_page)
+    app.router.add_post("/auth/cli/{request_id}", cli_approve_submit)
+
+
+def _safe_request_id(request_id: str) -> str | None:
+    """Reject anything that isn't 32 hex chars to keep this tight."""
+    if len(request_id) != 32:
+        return None
+    if not all(c in "0123456789abcdef" for c in request_id.lower()):
+        return None
+    return request_id
+
+
+async def cli_approve_page(request: web.Request) -> web.Response:
+    request_id = _safe_request_id(request.match_info["request_id"])
+    user = request.get("user") or {}
+    record = cli_auth_svc.get(request_id) if request_id else None
+
+    error = None
+    if record is None:
+        error = "This CLI login link is invalid, expired, or already consumed."
+    elif record["status"] != cli_auth_svc.PENDING:
+        error = f"This CLI login is already {record['status']}."
+    elif cli_auth_svc._is_expired(record):
+        error = "This CLI login link has expired. Please re-run `dc-portalctl auth login`."
+
+    return aiohttp_jinja2.render_template(
+        "auth/cli_approve.html", request,
+        {"user": user, "record": record, "request_id": request_id, "error": error},
+    )
+
+
+async def cli_approve_submit(request: web.Request) -> web.Response:
+    request_id = _safe_request_id(request.match_info["request_id"])
+    user = request.get("user") or {}
+    if request_id is None:
+        return aiohttp_jinja2.render_template(
+            "auth/cli_approve.html", request,
+            {"user": user, "record": None, "request_id": None,
+             "error": "Invalid request id."},
+        )
+
+    data = await request.post()
+    action = (data.get("action") or "").strip()
+
+    if action == "deny":
+        try:
+            cli_auth_svc.deny(request_id=request_id, user=user)
+        except cli_auth_svc.CliAuthError as e:
+            return aiohttp_jinja2.render_template(
+                "auth/cli_approve.html", request,
+                {"user": user, "record": None, "request_id": request_id, "error": str(e)},
+            )
+        return aiohttp_jinja2.render_template(
+            "auth/cli_approve.html", request,
+            {"user": user, "record": None, "request_id": request_id,
+             "denied": True, "error": None},
+        )
+
+    if action == "approve":
+        try:
+            updated = cli_auth_svc.approve(request_id=request_id, user=user)
+        except cli_auth_svc.CliAuthError as e:
+            return aiohttp_jinja2.render_template(
+                "auth/cli_approve.html", request,
+                {"user": user, "record": None, "request_id": request_id, "error": str(e)},
+            )
+        return aiohttp_jinja2.render_template(
+            "auth/cli_approve.html", request,
+            {"user": user, "record": updated, "request_id": request_id,
+             "approved": True, "error": None},
+        )
+
+    return aiohttp_jinja2.render_template(
+        "auth/cli_approve.html", request,
+        {"user": user, "record": cli_auth_svc.get(request_id), "request_id": request_id,
+         "error": "Unknown action."},
+    )

--- a/packages/device-connect-server/device_connect_server/portal/views/coding_agents.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/coding_agents.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Coding Agents tab: AGENTS.md handoff + per-user API token CRUD."""
+
+from __future__ import annotations
+
+import html as _html
+import logging
+
+import aiohttp_jinja2
+from aiohttp import web
+
+from ..services import tokens as tokens_svc
+
+logger = logging.getLogger(__name__)
+
+
+# Scopes a non-admin user may grant on a token they mint themselves.
+USER_SCOPES = [
+    "devices:read",
+    "devices:provision",
+    "devices:credentials",
+    "devices:invoke",
+    "events:read",
+]
+
+# Additional scopes available only to admins.
+ADMIN_SCOPES = ["admin:tenants", "admin:*"]
+
+
+def setup_routes(app: web.Application):
+    app.router.add_get("/coding-agents", coding_agents_page)
+    app.router.add_get("/coding-agents/AGENTS.md", download_agents_md)
+    app.router.add_get("/coding-agents/tokens", tokens_list_fragment)
+    app.router.add_post("/coding-agents/tokens", create_token)
+    app.router.add_post(
+        "/coding-agents/tokens/{token_id}/revoke", revoke_token,
+    )
+
+
+def _public_host(request: web.Request) -> str:
+    """Extract the public hostname/IP from the request (strip port)."""
+    return request.host.rsplit(":", 1)[0]
+
+
+def _portal_url(request: web.Request) -> str:
+    return f"{request.scheme}://{request.host}"
+
+
+def _allowed_scopes(role: str) -> list[str]:
+    if role == "admin":
+        return USER_SCOPES + ADMIN_SCOPES
+    return list(USER_SCOPES)
+
+
+def _list_user_tokens(user: dict) -> list[dict]:
+    return tokens_svc.list_tokens(
+        username=user["username"], tenant=user["tenant"],
+    )
+
+
+async def coding_agents_page(request: web.Request) -> web.Response:
+    user = request["user"]
+    tenant = user["tenant"]
+    portal_url = _portal_url(request)
+    public_host = _public_host(request)
+    tokens = _list_user_tokens(user)
+
+    return aiohttp_jinja2.render_template(
+        "coding_agents/page.html", request, {
+            "user": user,
+            "nav": "coding-agents",
+            "tenant": tenant,
+            "portal_url": portal_url,
+            "public_host": public_host,
+            "tokens": tokens,
+            "allowed_scopes": _allowed_scopes(user.get("role", "user")),
+            "default_scopes": list(USER_SCOPES),
+        },
+    )
+
+
+async def download_agents_md(request: web.Request) -> web.Response:
+    """Render AGENTS.md with the user's tenant + portal URL pre-filled."""
+    user = request["user"]
+    tenant = user["tenant"]
+    text = aiohttp_jinja2.render_string(
+        "coding_agents/AGENTS.md.j2", request, {
+            "tenant": tenant,
+            "portal_url": _portal_url(request),
+            "public_host": _public_host(request),
+            "example_device_id": f"{tenant}-cam-001",
+        },
+    )
+    return web.Response(
+        text=text,
+        content_type="text/markdown",
+        charset="utf-8",
+        headers={
+            "Content-Disposition": 'attachment; filename="AGENTS.md"',
+        },
+    )
+
+
+async def tokens_list_fragment(request: web.Request) -> web.Response:
+    """HTMX fragment: render the rows of the active-tokens table."""
+    user = request["user"]
+    tokens = _list_user_tokens(user)
+    return aiohttp_jinja2.render_template(
+        "coding_agents/_tokens_table.html", request, {
+            "tokens": tokens, "user": user,
+        },
+    )
+
+
+def _error_fragment(message: str) -> web.Response:
+    return web.Response(
+        text=(
+            '<div class="rounded-lg bg-red-50 border border-red-200 '
+            'px-4 py-3 text-sm text-red-700">'
+            f"{_html.escape(message)}</div>"
+        ),
+        content_type="text/html",
+    )
+
+
+async def create_token(request: web.Request) -> web.Response:
+    """Mint a token for the current user. HTMX returns the one-time secret panel."""
+    user = request["user"]
+    role = user.get("role", "user")
+    data = await request.post()
+
+    label = (data.get("label") or "").strip()
+    if len(label) > 80:
+        return _error_fragment("Label must be 80 characters or fewer.")
+
+    requested_scopes = data.getall("scopes") if hasattr(data, "getall") else []
+    # aiohttp's MultiDict supports getall; fall back to single value if not.
+    if not requested_scopes:
+        single = data.get("scopes")
+        requested_scopes = [single] if single else []
+
+    allowed = set(_allowed_scopes(role))
+    filtered = [s for s in requested_scopes if s in allowed]
+    if not filtered:
+        return _error_fragment("Pick at least one scope.")
+
+    try:
+        record = tokens_svc.create_token(
+            username=user["username"],
+            tenant=user["tenant"],
+            role=role,
+            scopes=filtered,
+            label=label,
+        )
+    except ValueError as e:
+        return _error_fragment(str(e))
+    except Exception as e:  # pragma: no cover - defensive: etcd outage etc.
+        logger.exception("Failed to create token")
+        return _error_fragment(f"Failed to create token: {e}")
+
+    return aiohttp_jinja2.render_template(
+        "coding_agents/_token_secret.html", request, {
+            "record": record,
+        },
+    )
+
+
+async def revoke_token(request: web.Request) -> web.Response:
+    """Revoke a token owned by the current user. Returns the refreshed table."""
+    user = request["user"]
+    token_id = request.match_info["token_id"]
+
+    record = tokens_svc.get_token_record(token_id)
+    if not record:
+        raise web.HTTPNotFound(text="Token not found")
+    # IDOR guard: only the owner (or an admin) can revoke.
+    if record["username"] != user["username"] and user.get("role") != "admin":
+        raise web.HTTPForbidden(text="Cannot revoke another user's token")
+
+    tokens_svc.revoke_token(token_id)
+
+    tokens = _list_user_tokens(user)
+    return aiohttp_jinja2.render_template(
+        "coding_agents/_tokens_table.html", request, {
+            "tokens": tokens, "user": user,
+        },
+    )

--- a/packages/device-connect-server/device_connect_server/portalctl/__init__.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""dc-portalctl — CLI client for the Device Connect Portal agent API."""

--- a/packages/device-connect-server/device_connect_server/portalctl/__main__.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/__main__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/device-connect-server/device_connect_server/portalctl/admin_tokens.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/admin_tokens.py
@@ -82,10 +82,10 @@ def _build_parser() -> argparse.ArgumentParser:
                    help="ISO-8601 expiry timestamp (optional)")
     c.set_defaults(func=_cmd_create)
 
-    l = sub.add_parser("list", help="list tokens (excludes secret material)")
-    l.add_argument("--user", default=None)
-    l.add_argument("--tenant", default=None)
-    l.set_defaults(func=_cmd_list)
+    lst = sub.add_parser("list", help="list tokens (excludes secret material)")
+    lst.add_argument("--user", default=None)
+    lst.add_argument("--tenant", default=None)
+    lst.set_defaults(func=_cmd_list)
 
     r = sub.add_parser("revoke", help="revoke a token by id")
     r.add_argument("--token-id", required=True)

--- a/packages/device-connect-server/device_connect_server/portalctl/admin_tokens.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/admin_tokens.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Admin-side token management for the agent API.
+
+Run on the portal host (talks directly to etcd; no Bearer token needed).
+This is the bootstrap path for minting the first token; further token CRUD
+can move to a portal browser UI in Phase 5.
+
+Usage:
+    python -m device_connect_server.portalctl.admin_tokens create \\
+        --user alice --tenant acme --role user \\
+        --scopes devices:read,devices:invoke --label ci-bot
+    python -m device_connect_server.portalctl.admin_tokens list [--user U] [--tenant T]
+    python -m device_connect_server.portalctl.admin_tokens revoke --token-id <id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from ..portal.services import tokens as tokens_svc
+
+
+def _cmd_create(args) -> int:
+    scopes = [s.strip() for s in args.scopes.split(",") if s.strip()]
+    try:
+        out = tokens_svc.create_token(
+            username=args.user,
+            tenant=args.tenant,
+            role=args.role,
+            scopes=scopes,
+            label=args.label or "",
+            expires_at=args.expires_at,
+        )
+    except ValueError as e:
+        sys.stderr.write(f"error: {e}\n")
+        return 2
+    json.dump(out, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    sys.stderr.write(
+        "\nIMPORTANT: the 'token' field is shown ONLY ONCE. "
+        "Save it somewhere safe; it cannot be recovered.\n"
+    )
+    return 0
+
+
+def _cmd_list(args) -> int:
+    rows = tokens_svc.list_tokens(username=args.user, tenant=args.tenant)
+    json.dump(rows, sys.stdout, indent=2, default=str)
+    sys.stdout.write("\n")
+    return 0
+
+
+def _cmd_revoke(args) -> int:
+    ok = tokens_svc.revoke_token(args.token_id)
+    if not ok:
+        sys.stderr.write(f"no token with id {args.token_id}\n")
+        return 1
+    print(f"revoked {args.token_id}")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m device_connect_server.portalctl.admin_tokens",
+        description="Admin-side token management (writes directly to etcd).",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    c = sub.add_parser("create", help="mint a new token (secret printed once)")
+    c.add_argument("--user", required=True)
+    c.add_argument("--tenant", required=True)
+    c.add_argument("--role", default="user", choices=["user", "admin"])
+    c.add_argument("--scopes", default="devices:read",
+                   help="comma-separated scopes")
+    c.add_argument("--label", default="")
+    c.add_argument("--expires-at", default=None,
+                   help="ISO-8601 expiry timestamp (optional)")
+    c.set_defaults(func=_cmd_create)
+
+    l = sub.add_parser("list", help="list tokens (excludes secret material)")
+    l.add_argument("--user", default=None)
+    l.add_argument("--tenant", default=None)
+    l.set_defaults(func=_cmd_list)
+
+    r = sub.add_parser("revoke", help="revoke a token by id")
+    r.add_argument("--token-id", required=True)
+    r.set_defaults(func=_cmd_revoke)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/device-connect-server/device_connect_server/portalctl/cli.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/cli.py
@@ -22,6 +22,7 @@ import asyncio
 import json
 import os
 import sys
+import time
 from typing import Any
 
 def _require_aiohttp():
@@ -36,6 +37,38 @@ def _require_aiohttp():
 DEFAULT_URL = "http://localhost:8080"
 ENV_URL = "DEVICE_CONNECT_PORTAL_URL"
 ENV_TOKEN = "DEVICE_CONNECT_PORTAL_TOKEN"
+
+# On-disk cached token written by `dc-portalctl auth login`.
+_TOKEN_FILE_DIR = os.path.join(
+    os.environ.get("XDG_CONFIG_HOME") or os.path.join(os.path.expanduser("~"), ".config"),
+    "dc-portalctl",
+)
+_TOKEN_FILE_PATH = os.path.join(_TOKEN_FILE_DIR, "token")
+
+# Default scopes requested by `auth login` if --scopes isn't given.
+_DEFAULT_LOGIN_SCOPES = [
+    "devices:read", "devices:provision", "devices:credentials",
+    "devices:invoke", "events:read",
+]
+
+
+def _read_cached_token() -> str | None:
+    try:
+        with open(_TOKEN_FILE_PATH, "r") as fp:
+            t = fp.read().strip()
+            return t or None
+    except OSError:
+        return None
+
+
+def _write_cached_token(token: str) -> str:
+    os.makedirs(_TOKEN_FILE_DIR, mode=0o700, exist_ok=True)
+    fd = os.open(_TOKEN_FILE_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, (token + "\n").encode())
+    finally:
+        os.close(fd)
+    return _TOKEN_FILE_PATH
 
 
 # ── output helpers ────────────────────────────────────────────────
@@ -110,12 +143,13 @@ class PortalClient:
                 return resp.status, body
 
 
-def _resolve_config(args) -> tuple[str, str]:
+def _resolve_config(args, *, token_required: bool = True) -> tuple[str, str]:
     url = args.portal_url or os.environ.get(ENV_URL) or DEFAULT_URL
-    token = args.token or os.environ.get(ENV_TOKEN) or ""
-    if not token:
+    token = args.token or os.environ.get(ENV_TOKEN) or _read_cached_token() or ""
+    if not token and token_required:
         sys.stderr.write(
-            f"error: no portal token provided. Set {ENV_TOKEN}=dcp_... or pass --token.\n"
+            f"error: no portal token provided. Run `dc-portalctl auth login` "
+            f"or set {ENV_TOKEN}=dcp_... or pass --token.\n"
         )
         raise SystemExit(2)
     return url, token
@@ -154,6 +188,81 @@ async def cmd_auth_me(client: PortalClient, args) -> int:
     if 200 <= status < 300:
         _emit(body, args.output)
     return _exit_for_status(status, body)
+
+
+async def cmd_auth_login(client: PortalClient, args) -> int:
+    """Browser-mediated login: print a URL, poll until the user approves."""
+    aiohttp = _require_aiohttp()
+    scopes = [s.strip() for s in (args.scopes or ",".join(_DEFAULT_LOGIN_SCOPES)).split(",")
+              if s.strip()]
+    label = args.label or f"dc-portalctl@{os.uname().nodename}"
+
+    init_status, init_body = await client.request(
+        "POST", "/api/agent/v1/auth/cli/init",
+        json_body={"scopes": scopes, "label": label},
+    )
+    if not (200 <= init_status < 300):
+        _maybe_print_error(init_status, init_body)
+        return _exit_for_status(init_status, init_body)
+
+    request_id = init_body["request_id"]
+    verification_url = init_body.get("verification_url") or (
+        client.base_url + f"/auth/cli/{request_id}"
+    )
+    poll_interval = float(init_body.get("poll_interval") or 3)
+
+    sys.stderr.write("\nOpen this URL in your browser to approve CLI access:\n\n")
+    sys.stderr.write(f"  {verification_url}\n\n")
+    sys.stderr.write(f"Requested scopes: {', '.join(scopes)}\n")
+    sys.stderr.write("Waiting for approval (Ctrl-C to cancel)... ")
+    sys.stderr.flush()
+
+    deadline = time.monotonic() + 600  # 10 min, matches server-side TTL
+    while time.monotonic() < deadline:
+        await asyncio.sleep(poll_interval)
+        sys.stderr.write(".")
+        sys.stderr.flush()
+        status, body = await client.request(
+            "POST", "/api/agent/v1/auth/cli/poll",
+            json_body={"request_id": request_id},
+        )
+        if status == 202:
+            continue
+        if 200 <= status < 300 and body.get("status") == "approved":
+            sys.stderr.write("\n")
+            token = body["token"]
+            if args.no_save:
+                sys.stderr.write(
+                    f"Logged in as {body['username']} ({body['tenant']}) — "
+                    f"scopes: {', '.join(body.get('scopes') or [])}.\n"
+                    f"Token (set {ENV_TOKEN}=...):\n"
+                )
+                print(token)
+            else:
+                path = _write_cached_token(token)
+                sys.stderr.write(
+                    f"Logged in as {body['username']} ({body['tenant']}) — "
+                    f"scopes: {', '.join(body.get('scopes') or [])}.\n"
+                    f"Token saved to {path}.\n"
+                )
+            return 0
+        # 410: denied / expired / not_found
+        sys.stderr.write("\n")
+        s = body.get("status") if isinstance(body, dict) else "error"
+        sys.stderr.write(f"login {s}.\n")
+        return 1
+
+    sys.stderr.write("\nlogin timed out waiting for approval.\n")
+    return 1
+
+
+async def cmd_auth_logout(client: PortalClient, args) -> int:
+    try:
+        os.remove(_TOKEN_FILE_PATH)
+        sys.stderr.write(f"removed {_TOKEN_FILE_PATH}\n")
+    except FileNotFoundError:
+        sys.stderr.write("no cached token to remove.\n")
+    return 0
 
 
 async def cmd_fleet(client: PortalClient, args) -> int:
@@ -412,11 +521,26 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sub = p.add_subparsers(dest="cmd", required=True)
 
-    # auth me
+    # auth ...
     auth = sub.add_parser("auth", help="authentication / identity")
     auth_sub = auth.add_subparsers(dest="auth_cmd", required=True)
     auth_sub.add_parser("me", help="show identity + scopes for the current token") \
         .set_defaults(func=cmd_auth_me)
+
+    a_login = auth_sub.add_parser(
+        "login",
+        help="browser-mediated login: print a URL, save the token on approve",
+    )
+    a_login.add_argument("--scopes",
+                         help=("comma-separated scopes to request "
+                               f"(default: {','.join(_DEFAULT_LOGIN_SCOPES)})"))
+    a_login.add_argument("--label", help="human label saved alongside the token")
+    a_login.add_argument("--no-save", action="store_true",
+                         help="print the token to stdout instead of caching it on disk")
+    a_login.set_defaults(func=cmd_auth_login, _no_token=True)
+
+    auth_sub.add_parser("logout", help="remove the cached token") \
+        .set_defaults(func=cmd_auth_logout, _no_token=True)
 
     # fleet describe
     fleet = sub.add_parser("fleet", help="fleet-level queries")
@@ -505,7 +629,7 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
-    url, token = _resolve_config(args)
+    url, token = _resolve_config(args, token_required=not getattr(args, "_no_token", False))
     client = PortalClient(url, token)
     try:
         return asyncio.run(args.func(client, args))

--- a/packages/device-connect-server/device_connect_server/portalctl/cli.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/cli.py
@@ -1,0 +1,517 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""dc-portalctl — CLI for the Device Connect Portal agent API.
+
+Designed for coding agents and CI: JSON output by default, exit codes that
+distinguish auth/scope/server errors, and bounded event streaming that never
+hangs by accident.
+
+Configuration:
+    DEVICE_CONNECT_PORTAL_URL    base URL (default: http://localhost:8080)
+    DEVICE_CONNECT_PORTAL_TOKEN  Bearer token (dcp_...)
+
+See `dc-portalctl --help` for the full command list.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+
+def _require_aiohttp():
+    try:
+        import aiohttp  # noqa: F401
+        return aiohttp
+    except ImportError as e:
+        sys.stderr.write("dc-portalctl requires aiohttp (install device-connect-server[portal])\n")
+        raise SystemExit(1) from e
+
+
+DEFAULT_URL = "http://localhost:8080"
+ENV_URL = "DEVICE_CONNECT_PORTAL_URL"
+ENV_TOKEN = "DEVICE_CONNECT_PORTAL_TOKEN"
+
+
+# ── output helpers ────────────────────────────────────────────────
+
+
+def _emit_json(value: Any, fp=None) -> None:
+    fp = fp or sys.stdout
+    json.dump(value, fp, indent=2, sort_keys=False, default=str)
+    fp.write("\n")
+    fp.flush()
+
+
+def _emit_compact(value: Any) -> None:
+    """Compact human-readable view for read-only commands."""
+    if isinstance(value, list):
+        for item in value:
+            _emit_compact(item)
+        return
+    if isinstance(value, dict):
+        if "device_id" in value:
+            line = value["device_id"]
+            if "device_type" in value or "identity" in value:
+                ident = value.get("identity") or {}
+                dtype = value.get("device_type") or ident.get("device_type") or ""
+                if dtype:
+                    line += f"\t{dtype}"
+            status = value.get("status") or {}
+            if isinstance(status, dict):
+                avail = status.get("availability")
+                if avail:
+                    line += f"\t{avail}"
+            print(line)
+            return
+    print(value)
+
+
+def _emit(value: Any, fmt: str) -> None:
+    if fmt == "json":
+        _emit_json(value)
+    elif fmt == "compact":
+        _emit_compact(value)
+    elif fmt == "table":
+        _emit_compact(value)
+    else:
+        _emit_json(value)
+
+
+# ── HTTP client ───────────────────────────────────────────────────
+
+
+class PortalClient:
+    def __init__(self, base_url: str, token: str):
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+
+    @property
+    def headers(self) -> dict:
+        return {"Authorization": f"Bearer {self.token}", "Accept": "application/json"}
+
+    async def request(self, method: str, path: str, *, json_body: dict | None = None,
+                      params: dict | None = None) -> tuple[int, Any]:
+        aiohttp = _require_aiohttp()
+        url = self.base_url + path
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=self.headers,
+                                       json=json_body, params=params) as resp:
+                text = await resp.text()
+                try:
+                    body = json.loads(text) if text else {}
+                except json.JSONDecodeError:
+                    body = {"raw": text}
+                return resp.status, body
+
+
+def _resolve_config(args) -> tuple[str, str]:
+    url = args.portal_url or os.environ.get(ENV_URL) or DEFAULT_URL
+    token = args.token or os.environ.get(ENV_TOKEN) or ""
+    if not token:
+        sys.stderr.write(
+            f"error: no portal token provided. Set {ENV_TOKEN}=dcp_... or pass --token.\n"
+        )
+        raise SystemExit(2)
+    return url, token
+
+
+def _exit_for_status(status: int, body: Any) -> int:
+    """Map HTTP status to an exit code agents can branch on."""
+    if 200 <= status < 300:
+        return 0
+    if status == 401:
+        return 4
+    if status == 403:
+        return 5
+    if status == 404:
+        return 6
+    return 1
+
+
+def _maybe_print_error(status: int, body: Any):
+    if 200 <= status < 300:
+        return
+    sys.stderr.write(f"HTTP {status}: ")
+    if isinstance(body, dict) and body.get("error"):
+        err = body["error"]
+        sys.stderr.write(f"{err.get('code', '?')}: {err.get('message', '')}\n")
+    else:
+        sys.stderr.write(json.dumps(body) + "\n")
+
+
+# ── commands ──────────────────────────────────────────────────────
+
+
+async def cmd_auth_me(client: PortalClient, args) -> int:
+    status, body = await client.request("GET", "/api/agent/v1/me")
+    _maybe_print_error(status, body)
+    if 200 <= status < 300:
+        _emit(body, args.output)
+    return _exit_for_status(status, body)
+
+
+async def cmd_fleet(client: PortalClient, args) -> int:
+    params = {"tenant": args.tenant} if args.tenant else None
+    status, body = await client.request("GET", "/api/agent/v1/fleet", params=params)
+    _maybe_print_error(status, body)
+    if 200 <= status < 300:
+        _emit(body, args.output)
+    return _exit_for_status(status, body)
+
+
+async def cmd_devices_list(client: PortalClient, args) -> int:
+    params: dict[str, Any] = {"offset": args.offset, "limit": args.limit}
+    if args.tenant:
+        params["tenant"] = args.tenant
+    status, body = await client.request("GET", "/api/agent/v1/devices", params=params)
+    _maybe_print_error(status, body)
+    if 200 <= status < 300:
+        _emit(body, args.output)
+    return _exit_for_status(status, body)
+
+
+def _device_subpath(device_id: str, sub: str) -> str:
+    return f"/api/agent/v1/devices/{device_id}{sub}"
+
+
+async def cmd_devices_get(client: PortalClient, args) -> int:
+    return await _simple_get(client, args, _device_subpath(args.device_id, ""))
+
+
+async def cmd_devices_identity(client: PortalClient, args) -> int:
+    return await _simple_get(client, args, _device_subpath(args.device_id, "/identity"))
+
+
+async def cmd_devices_status(client: PortalClient, args) -> int:
+    return await _simple_get(client, args, _device_subpath(args.device_id, "/status"))
+
+
+async def cmd_devices_capabilities(client: PortalClient, args) -> int:
+    return await _simple_get(client, args, _device_subpath(args.device_id, "/capabilities"))
+
+
+async def cmd_devices_functions(client: PortalClient, args) -> int:
+    return await _simple_get(client, args, _device_subpath(args.device_id, "/functions"))
+
+
+async def cmd_devices_events(client: PortalClient, args) -> int:
+    return await _simple_get(client, args, _device_subpath(args.device_id, "/events"))
+
+
+async def _simple_get(client: PortalClient, args, path: str) -> int:
+    params = {"tenant": args.tenant} if getattr(args, "tenant", None) else None
+    status, body = await client.request("GET", path, params=params)
+    _maybe_print_error(status, body)
+    if 200 <= status < 300:
+        _emit(body, args.output)
+    return _exit_for_status(status, body)
+
+
+async def cmd_devices_provision(client: PortalClient, args) -> int:
+    body_in = {"device_name": args.device_name}
+    if args.device_type:
+        body_in["device_type"] = args.device_type
+    if args.location:
+        body_in["location"] = args.location
+    if args.description:
+        body_in["description"] = args.description
+    if args.metadata:
+        meta = {}
+        for kv in args.metadata:
+            if "=" not in kv:
+                sys.stderr.write(f"--metadata expects key=value, got: {kv}\n")
+                return 2
+            k, v = kv.split("=", 1)
+            meta[k] = v
+        body_in["metadata"] = meta
+
+    params = {"tenant": args.tenant} if args.tenant else None
+    status, body = await client.request("POST", "/api/agent/v1/devices",
+                                        json_body=body_in, params=params)
+    _maybe_print_error(status, body)
+    if not (200 <= status < 300):
+        return _exit_for_status(status, body)
+
+    result = (body or {}).get("result") or {}
+    creds = result.get("credentials") or {}
+    if args.creds_output_file:
+        try:
+            with open(args.creds_output_file, "w") as fp:
+                json.dump(creds.get("content") or {}, fp, indent=2)
+                fp.write("\n")
+            sys.stderr.write(f"Wrote credentials to {args.creds_output_file}\n")
+        except OSError as e:
+            sys.stderr.write(f"failed to write credentials file: {e}\n")
+            return 1
+    _emit(body, args.output)
+    return 0
+
+
+async def cmd_devices_credentials(client: PortalClient, args) -> int:
+    params = {"tenant": args.tenant} if args.tenant else None
+    status, body = await client.request(
+        "GET", _device_subpath(args.device_id, "/credentials"), params=params,
+    )
+    _maybe_print_error(status, body)
+    if not (200 <= status < 300):
+        return _exit_for_status(status, body)
+    result = (body or {}).get("result") or {}
+    if args.output_file:
+        try:
+            with open(args.output_file, "w") as fp:
+                json.dump(result.get("content") or {}, fp, indent=2)
+                fp.write("\n")
+            sys.stderr.write(f"Wrote credentials to {args.output_file}\n")
+        except OSError as e:
+            sys.stderr.write(f"failed to write credentials file: {e}\n")
+            return 1
+        return 0
+    _emit(body, args.output)
+    return 0
+
+
+async def cmd_devices_revoke_credentials(client: PortalClient, args) -> int:
+    params = {"tenant": args.tenant} if args.tenant else None
+    status, body = await client.request(
+        "POST", _device_subpath(args.device_id, "/credentials:rotate"), params=params,
+    )
+    _maybe_print_error(status, body)
+    if 200 <= status < 300:
+        _emit(body, args.output)
+    return _exit_for_status(status, body)
+
+
+async def cmd_devices_delete(client: PortalClient, args) -> int:
+    if not args.confirm:
+        sys.stderr.write("delete requires --confirm to proceed\n")
+        return 2
+    params = {"tenant": args.tenant} if args.tenant else None
+    status, body = await client.request(
+        "DELETE", _device_subpath(args.device_id, ""), params=params,
+    )
+    _maybe_print_error(status, body)
+    if 200 <= status < 300:
+        _emit(body, args.output)
+    return _exit_for_status(status, body)
+
+
+async def cmd_devices_invoke(client: PortalClient, args) -> int:
+    try:
+        params_obj = json.loads(args.params) if args.params else {}
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"--params must be valid JSON: {e}\n")
+        return 2
+    body_in = {
+        "function": args.function,
+        "params": params_obj,
+        "timeout": args.timeout,
+    }
+    if args.reason:
+        body_in["reason"] = args.reason
+    qs = {"tenant": args.tenant} if args.tenant else None
+    status, body = await client.request(
+        "POST", _device_subpath(args.device_id, "/invoke"),
+        json_body=body_in, params=qs,
+    )
+    _maybe_print_error(status, body)
+    if 200 <= status < 300:
+        _emit(body, args.output)
+    return _exit_for_status(status, body)
+
+
+async def cmd_devices_invoke_fallback(client: PortalClient, args) -> int:
+    try:
+        params_obj = json.loads(args.params) if args.params else {}
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"--params must be valid JSON: {e}\n")
+        return 2
+    ids = [s.strip() for s in args.device_ids.split(",") if s.strip()]
+    if not ids:
+        sys.stderr.write("no device ids provided\n")
+        return 2
+    body_in = {
+        "device_ids": ids,
+        "function": args.function,
+        "params": params_obj,
+        "timeout": args.timeout,
+    }
+    if args.reason:
+        body_in["reason"] = args.reason
+    qs = {"tenant": args.tenant} if args.tenant else None
+    status, body = await client.request(
+        "POST", "/api/agent/v1/invoke-with-fallback", json_body=body_in, params=qs,
+    )
+    _maybe_print_error(status, body)
+    if 200 <= status < 300:
+        _emit(body, args.output)
+    return _exit_for_status(status, body)
+
+
+async def cmd_devices_stream(client: PortalClient, args) -> int:
+    if args.duration is None and args.count is None and not args.follow:
+        sys.stderr.write(
+            "error: stream requires at least one of --duration, --count, or --follow\n"
+        )
+        return 2
+
+    aiohttp = _require_aiohttp()
+    from .streaming import stream_ndjson
+
+    qs: dict[str, Any] = {"format": args.format}
+    if args.duration is not None:
+        qs["duration"] = args.duration
+    if args.count is not None:
+        qs["count"] = args.count
+    if args.follow:
+        qs["follow"] = "true"
+    if args.tenant:
+        qs["tenant"] = args.tenant
+
+    url = client.base_url + _device_subpath(args.device_id, f"/events/{args.event_name}/stream")
+    async with aiohttp.ClientSession() as session:
+        # Build query string ourselves to keep it readable in error messages
+        from urllib.parse import urlencode
+        full_url = url + "?" + urlencode(qs)
+        if args.format == "ndjson":
+            exit_code, _events, _closed_by = await stream_ndjson(
+                session, full_url, client.headers,
+                duration=args.duration, count=args.count, follow=args.follow,
+            )
+            return exit_code
+        # SSE: pass through with no client-side _meta trailer
+        async with session.get(full_url, headers=client.headers) as resp:
+            if resp.status >= 400:
+                txt = await resp.text()
+                sys.stderr.write(f"stream failed: HTTP {resp.status}: {txt}\n")
+                return _exit_for_status(resp.status, {})
+            async for raw in resp.content:
+                sys.stdout.write(raw.decode(errors="replace"))
+                sys.stdout.flush()
+            return 0
+
+
+# ── argparse wiring ────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="dc-portalctl",
+        description="CLI client for the Device Connect Portal agent API",
+    )
+    p.add_argument("--portal-url", help=f"portal base URL (default ${ENV_URL} or {DEFAULT_URL})")
+    p.add_argument("--token", help=f"bearer token (default ${ENV_TOKEN})")
+    p.add_argument("--tenant", help="tenant override (admin only)")
+    p.add_argument("--output", choices=["json", "table", "compact"], default="json",
+                   help="output format (default: json)")
+
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    # auth me
+    auth = sub.add_parser("auth", help="authentication / identity")
+    auth_sub = auth.add_subparsers(dest="auth_cmd", required=True)
+    auth_sub.add_parser("me", help="show identity + scopes for the current token") \
+        .set_defaults(func=cmd_auth_me)
+
+    # fleet describe
+    fleet = sub.add_parser("fleet", help="fleet-level queries")
+    fsub = fleet.add_subparsers(dest="fleet_cmd", required=True)
+    fsub.add_parser("describe", help="fleet summary").set_defaults(func=cmd_fleet)
+
+    # devices ...
+    devices = sub.add_parser("devices", help="device operations")
+    dsub = devices.add_subparsers(dest="devices_cmd", required=True)
+
+    d_list = dsub.add_parser("list", help="list devices")
+    d_list.add_argument("--offset", type=int, default=0)
+    d_list.add_argument("--limit", type=int, default=200)
+    d_list.set_defaults(func=cmd_devices_list)
+
+    for name, fn, help_ in [
+        ("get", cmd_devices_get, "whole device record"),
+        ("identity", cmd_devices_identity, "identity sub-object"),
+        ("status", cmd_devices_status, "entire status sub-object"),
+        ("capabilities", cmd_devices_capabilities, "{functions, events}"),
+        ("functions", cmd_devices_functions, "device functions"),
+        ("events", cmd_devices_events, "device events"),
+    ]:
+        sp = dsub.add_parser(name, help=help_)
+        sp.add_argument("device_id")
+        sp.set_defaults(func=fn)
+
+    d_prov = dsub.add_parser("provision", help="create a new device + return credentials")
+    d_prov.add_argument("device_name")
+    d_prov.add_argument("--device-type")
+    d_prov.add_argument("--location")
+    d_prov.add_argument("--description")
+    d_prov.add_argument("--metadata", action="append", default=[],
+                        help="key=value (repeatable)")
+    d_prov.add_argument("--creds-output-file",
+                        help="write credentials JSON to this path")
+    d_prov.set_defaults(func=cmd_devices_provision)
+
+    d_creds = dsub.add_parser("credentials", help="re-download credentials for a device")
+    d_creds.add_argument("device_id")
+    d_creds.add_argument("--output-file", help="write credentials JSON to this path")
+    d_creds.set_defaults(func=cmd_devices_credentials)
+
+    d_rev = dsub.add_parser("revoke-credentials", help="rotate / invalidate credentials")
+    d_rev.add_argument("device_id")
+    d_rev.set_defaults(func=cmd_devices_revoke_credentials)
+
+    d_del = dsub.add_parser("delete", help="decommission a device")
+    d_del.add_argument("device_id")
+    d_del.add_argument("--confirm", action="store_true",
+                       help="required: confirms the destructive action")
+    d_del.set_defaults(func=cmd_devices_delete)
+
+    d_inv = dsub.add_parser("invoke", help="invoke a device function")
+    d_inv.add_argument("device_id")
+    d_inv.add_argument("function")
+    d_inv.add_argument("--params", default="{}", help="JSON params object")
+    d_inv.add_argument("--reason", help="agent reasoning (audited, truncated)")
+    d_inv.add_argument("--timeout", type=float, default=10.0)
+    d_inv.set_defaults(func=cmd_devices_invoke)
+
+    d_invf = dsub.add_parser("invoke-fallback",
+                             help="try a comma-separated device list in order")
+    d_invf.add_argument("device_ids", help="comma-separated list")
+    d_invf.add_argument("function")
+    d_invf.add_argument("--params", default="{}")
+    d_invf.add_argument("--reason")
+    d_invf.add_argument("--timeout", type=float, default=10.0)
+    d_invf.set_defaults(func=cmd_devices_invoke_fallback)
+
+    d_str = dsub.add_parser("stream", help="bounded event stream for a device")
+    d_str.add_argument("device_id")
+    d_str.add_argument("event_name")
+    d_str.add_argument("--format", choices=["ndjson", "sse"], default="ndjson")
+    d_str.add_argument("--duration", type=float,
+                       help="max wall-clock seconds before the stream closes")
+    d_str.add_argument("--count", type=int,
+                       help="max events delivered before the stream closes")
+    d_str.add_argument("--follow", action="store_true",
+                       help="explicit unbounded mode (still capped server-side)")
+    d_str.set_defaults(func=cmd_devices_stream)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    url, token = _resolve_config(args)
+    client = PortalClient(url, token)
+    try:
+        return asyncio.run(args.func(client, args))
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/device-connect-server/device_connect_server/portalctl/cli.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/cli.py
@@ -21,6 +21,7 @@ import argparse
 import asyncio
 import json
 import os
+import socket
 import sys
 import time
 from typing import Any
@@ -63,6 +64,13 @@ def _read_cached_token() -> str | None:
 
 def _write_cached_token(token: str) -> str:
     os.makedirs(_TOKEN_FILE_DIR, mode=0o700, exist_ok=True)
+    # makedirs(exist_ok=True) does not chmod a pre-existing dir; force it on POSIX
+    # so a token written into a world-readable dir is still protected.
+    if os.name == "posix":
+        try:
+            os.chmod(_TOKEN_FILE_DIR, 0o700)
+        except OSError:
+            pass
     fd = os.open(_TOKEN_FILE_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
         os.write(fd, (token + "\n").encode())
@@ -192,10 +200,10 @@ async def cmd_auth_me(client: PortalClient, args) -> int:
 
 async def cmd_auth_login(client: PortalClient, args) -> int:
     """Browser-mediated login: print a URL, poll until the user approves."""
-    aiohttp = _require_aiohttp()
+    _require_aiohttp()
     scopes = [s.strip() for s in (args.scopes or ",".join(_DEFAULT_LOGIN_SCOPES)).split(",")
               if s.strip()]
-    label = args.label or f"dc-portalctl@{os.uname().nodename}"
+    label = args.label or f"dc-portalctl@{socket.gethostname() or 'unknown'}"
 
     init_status, init_body = await client.request(
         "POST", "/api/agent/v1/auth/cli/init",
@@ -231,10 +239,17 @@ async def cmd_auth_login(client: PortalClient, args) -> int:
         if 200 <= status < 300 and body.get("status") == "approved":
             sys.stderr.write("\n")
             token = body["token"]
+            granted = body.get("scopes") or []
+            dropped = sorted(set(scopes) - set(granted))
+            if dropped:
+                sys.stderr.write(
+                    f"Note: requested scopes {dropped} were not granted "
+                    f"(insufficient role/permission); proceeding with the granted subset.\n"
+                )
             if args.no_save:
                 sys.stderr.write(
                     f"Logged in as {body['username']} ({body['tenant']}) — "
-                    f"scopes: {', '.join(body.get('scopes') or [])}.\n"
+                    f"scopes: {', '.join(granted)}.\n"
                     f"Token (set {ENV_TOKEN}=...):\n"
                 )
                 print(token)
@@ -242,7 +257,7 @@ async def cmd_auth_login(client: PortalClient, args) -> int:
                 path = _write_cached_token(token)
                 sys.stderr.write(
                     f"Logged in as {body['username']} ({body['tenant']}) — "
-                    f"scopes: {', '.join(body.get('scopes') or [])}.\n"
+                    f"scopes: {', '.join(granted)}.\n"
                     f"Token saved to {path}.\n"
                 )
             return 0

--- a/packages/device-connect-server/device_connect_server/portalctl/streaming.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/streaming.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded NDJSON event-stream reader for `dc-portalctl devices stream`.
+
+Race three signals: server payload, wall-clock duration, event count. Whichever
+hits first wins; emit a `_meta` trailer locally if the server doesn't (older
+servers / SSE format).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import time
+from typing import IO
+
+
+async def stream_ndjson(
+    session,
+    url: str,
+    headers: dict,
+    *,
+    duration: float | None,
+    count: int | None,
+    follow: bool,
+    out: IO[str] | None = None,
+) -> tuple[int, int, str]:
+    """Read NDJSON from the URL line-by-line, enforcing duration/count locally.
+
+    The server also enforces these caps; the client enforces them too so a
+    misbehaving or proxy-buffered server can't hang the agent.
+
+    Returns (exit_code, events_received, closed_by).
+    """
+    if out is None:
+        out = sys.stdout
+    started = time.monotonic()
+    events = 0
+    closed_by = "server"
+    saw_meta = False
+
+    async with session.get(url, headers=headers) as resp:
+        if resp.status >= 400:
+            text = await resp.text()
+            sys.stderr.write(f"stream failed: HTTP {resp.status}: {text}\n")
+            return 1, 0, "error"
+
+        async for raw in resp.content:
+            if not raw:
+                continue
+            line = raw.decode(errors="replace").strip()
+            if not line:
+                continue
+
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                # Pass through anything we can't parse so the user can see it
+                out.write(line + "\n")
+                out.flush()
+                continue
+
+            if isinstance(obj, dict) and "_meta" in obj:
+                saw_meta = True
+                meta = obj["_meta"]
+                closed_by = str(meta.get("closed_by") or closed_by)
+                events = int(meta.get("events_received") or events)
+                out.write(json.dumps(obj) + "\n")
+                out.flush()
+                break
+
+            events += 1
+            out.write(json.dumps(obj) + "\n")
+            out.flush()
+
+            elapsed = time.monotonic() - started
+            if duration is not None and elapsed >= duration and not follow:
+                closed_by = "duration"
+                break
+            if count is not None and events >= count and not follow:
+                closed_by = "count"
+                break
+
+    elapsed = time.monotonic() - started
+    if not saw_meta:
+        out.write(json.dumps({"_meta": {
+            "closed_by": closed_by,
+            "events_received": events,
+            "elapsed_s": round(elapsed, 3),
+        }}) + "\n")
+        out.flush()
+
+    if events == 0 and closed_by == "duration":
+        return 2, events, closed_by  # documented "no events" exit code
+    return 0, events, closed_by
+
+
+def race_with_timer(coro, duration: float | None):
+    """Race a coroutine against an asyncio sleep — used as belt-and-braces fallback.
+
+    Currently unused (the line-loop polls the wall clock itself), but kept here
+    if a future blocking variant is needed.
+    """
+    if duration is None:
+        return coro
+    return asyncio.wait_for(coro, timeout=duration + 5.0)

--- a/packages/device-connect-server/docker-compose.yml
+++ b/packages/device-connect-server/docker-compose.yml
@@ -9,7 +9,16 @@ services:
       - "4222:4222"
       - "8222:8222"
     volumes:
-      - ./security_infra/nats-jwt-generated.conf:/etc/nats/nats-jwt.conf:ro
+      # Long-form bind with create_host_path: false so docker fails loudly if
+      # nats-jwt-generated.conf is missing instead of silently creating an
+      # empty directory in its place (which causes NATS to crash-loop with
+      # "is a directory"). Run security_infra/setup_deployment.sh first.
+      - type: bind
+        source: ./security_infra/nats-jwt-generated.conf
+        target: /etc/nats/nats-jwt.conf
+        read_only: true
+        bind:
+          create_host_path: false
     command: ["-c", "/etc/nats/nats-jwt.conf"]
 
   etcd:

--- a/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
+++ b/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
@@ -26,7 +26,16 @@ services:
       - "4222:4222"
       - "8222:8222"
     volumes:
-      - ../security_infra/nats-jwt-generated.conf:/etc/nats/nats.conf:ro
+      # Long-form bind with create_host_path: false so docker fails loudly if
+      # nats-jwt-generated.conf is missing instead of silently creating an
+      # empty directory in its place (which causes NATS to crash-loop with
+      # "is a directory"). Run security_infra/setup_deployment.sh first.
+      - type: bind
+        source: ../security_infra/nats-jwt-generated.conf
+        target: /etc/nats/nats.conf
+        read_only: true
+        bind:
+          create_host_path: false
     command: ["-c", "/etc/nats/nats.conf"]
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8222/healthz"]

--- a/packages/device-connect-server/infra/docker-compose-nats.yml
+++ b/packages/device-connect-server/infra/docker-compose-nats.yml
@@ -18,7 +18,16 @@ services:
       - "4222:4222"
       - "8222:8222"
     volumes:
-      - ../security_infra/nats-jwt-generated.conf:/etc/nats/nats-jwt.conf:ro
+      # Long-form bind with create_host_path: false so docker fails loudly if
+      # nats-jwt-generated.conf is missing instead of silently creating an
+      # empty directory in its place (which causes NATS to crash-loop with
+      # "is a directory"). Run security_infra/setup_deployment.sh first.
+      - type: bind
+        source: ../security_infra/nats-jwt-generated.conf
+        target: /etc/nats/nats-jwt.conf
+        read_only: true
+        bind:
+          create_host_path: false
     command: ["-c", "/etc/nats/nats-jwt.conf"]
 
   etcd:

--- a/packages/device-connect-server/pyproject.toml
+++ b/packages/device-connect-server/pyproject.toml
@@ -90,4 +90,4 @@ Security = "https://github.com/arm/device-connect?tab=security-ov-file"
 include = ["device_connect_server*"]
 
 [tool.setuptools.package-data]
-"device_connect_server.portal" = ["templates/**/*.html", "static/**/*"]
+"device_connect_server.portal" = ["templates/**/*", "static/**/*"]

--- a/packages/device-connect-server/pyproject.toml
+++ b/packages/device-connect-server/pyproject.toml
@@ -75,6 +75,7 @@ all = [
 devctl = "device_connect_server.devctl.cli:main"
 statectl = "device_connect_server.statectl.cli:main"
 dc-portal = "device_connect_server.portal.__main__:main"
+dc-portalctl = "device_connect_server.portalctl.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/arm/device-connect"

--- a/packages/device-connect-server/security_infra/README.md
+++ b/packages/device-connect-server/security_infra/README.md
@@ -57,7 +57,7 @@ For deployments where multiple groups share the same infrastructure (workshops, 
 
 | Tool | Required for | Install |
 |------|-------------|---------|
-| [nsc](https://github.com/nats-io/nsc) | All JWT scripts | `brew install nsc` or `go install github.com/nats-io/nsc/v2@latest` |
+| [nsc](https://github.com/nats-io/nsc) | All JWT scripts | `brew install nsc` (macOS) or `go install github.com/nats-io/nsc/v2@latest` (then `sudo ln -sf "$(go env GOPATH)/bin/nsc" /usr/local/bin/nsc`) |
 | [Docker](https://docs.docker.com/get-docker/) | Running infrastructure | docker.com |
 | [nats CLI](https://github.com/nats-io/natscli) | `verify_tenants.sh` only | `brew install nats-io/nats-tools/nats` |
 | Python 3.10+ | `manage_tenants.sh list` | Usually pre-installed |

--- a/packages/device-connect-server/security_infra/setup_deployment.sh
+++ b/packages/device-connect-server/security_infra/setup_deployment.sh
@@ -96,6 +96,9 @@ export XDG_DATA_HOME="${NSC_HOME}/data"
 export XDG_CONFIG_HOME="${NSC_HOME}/config"
 
 OUTPUT_CONF="${SCRIPT_DIR}/nats-jwt-generated.conf"
+# Newer nsc (v2.12+) refuses to overwrite an existing --config-file, and Step 1
+# (setup_jwt_auth.sh) has already created this file, so remove it first.
+rm -f "${OUTPUT_CONF}"
 nsc generate config --mem-resolver --config-file "${OUTPUT_CONF}"
 
 # Re-append listen directives (nsc generate overwrites the file)

--- a/packages/device-connect-server/tests/device_connect_server/test_portal_agent_api.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portal_agent_api.py
@@ -1,0 +1,301 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the /api/agent/v1/* agent API.
+
+Covers auth middleware behavior, scope enforcement, and the read endpoints
+that must return whole sub-objects (status, identity, capabilities) byte-equal
+with the registry document.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from device_connect_server.portal.app import auth_middleware
+from device_connect_server.portal.services import tokens as tokens_svc
+from device_connect_server.portal.views import agent_api
+
+
+# A registry doc with extra fields the API must surface untouched.
+SAMPLE_DEVICE = {
+    "device_id": "acme-cam-001",
+    "tenant": "acme",
+    "identity": {
+        "device_type": "camera",
+        "manufacturer": "Acme",
+        "model": "C-1",
+        "firmware_version": "1.2.3",
+        "description": "lobby cam",
+        "x_custom_extra_field": "registry-added-later",
+    },
+    "status": {
+        "ts": 1746480000.123,
+        "availability": "available",
+        "location": "warehouse1/loading-dock",
+        "busy_score": 0.12,
+        "battery": 87,
+        "online": True,
+        "error_state": None,
+        "x_some_new_status_field": "added-by-newer-driver",
+    },
+    "capabilities": {
+        "description": "Camera with motion detection",
+        "functions": [
+            {"name": "capture_frame", "description": "Take a picture",
+             "parameters": {"type": "object"}, "tags": []},
+        ],
+        "events": [
+            {"name": "motion_detected", "description": "...",
+             "payload_schema": {"type": "object"}, "tags": []},
+        ],
+    },
+    "registry": {"registered_at": "2026-05-01T12:00:00+00:00"},
+}
+
+
+@pytest.fixture
+def fake_record():
+    """A fake (verified) token record used by the auth middleware."""
+    return {
+        "token_id": "abc123",
+        "username": "alice",
+        "tenant": "acme",
+        "role": "user",
+        "scopes": ["devices:read"],
+        "created_at": "2026-05-01T00:00:00+00:00",
+    }
+
+
+@pytest.fixture
+def admin_record():
+    return {
+        "token_id": "admin0",
+        "username": "root",
+        "tenant": "acme",
+        "role": "admin",
+        "scopes": ["devices:read", "devices:provision", "devices:credentials",
+                   "devices:invoke", "events:read", "admin:*"],
+        "created_at": "2026-05-01T00:00:00+00:00",
+    }
+
+
+def _build_app() -> web.Application:
+    app = web.Application(middlewares=[auth_middleware])
+    agent_api.setup_routes(app)
+    return app
+
+
+@pytest.fixture
+async def client(fake_record):
+    app = _build_app()
+    server = TestServer(app)
+    async with server:
+        async with TestClient(server) as cli:
+            with patch.object(tokens_svc, "verify_token", return_value=fake_record):
+                yield cli
+
+
+@pytest.fixture
+async def admin_client(admin_record):
+    app = _build_app()
+    server = TestServer(app)
+    async with server:
+        async with TestClient(server) as cli:
+            with patch.object(tokens_svc, "verify_token", return_value=admin_record):
+                yield cli
+
+
+def H(token: str = "dcp_x_y") -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── auth middleware ───────────────────────────────────────────────
+
+
+class TestAgentAuth:
+    async def test_no_token_returns_json_401(self):
+        app = _build_app()
+        server = TestServer(app)
+        async with server:
+            async with TestClient(server) as cli:
+                r = await cli.get("/api/agent/v1/me")
+                assert r.status == 401
+                assert r.headers["Content-Type"].startswith("application/json")
+                body = await r.json()
+                assert body["success"] is False
+                assert body["error"]["code"] == "missing_token"
+
+    async def test_bad_token_returns_json_401(self):
+        app = _build_app()
+        server = TestServer(app)
+        async with server:
+            async with TestClient(server) as cli:
+                with patch.object(tokens_svc, "verify_token", return_value=None):
+                    r = await cli.get("/api/agent/v1/me", headers=H("dcp_bad"))
+                    assert r.status == 401
+                    body = await r.json()
+                    assert body["error"]["code"] == "invalid_token"
+
+
+# ── /me ───────────────────────────────────────────────────────────
+
+
+class TestMe:
+    async def test_me_echoes_token_record(self, client, fake_record):
+        r = await client.get("/api/agent/v1/me", headers=H())
+        assert r.status == 200
+        body = await r.json()
+        assert body["username"] == fake_record["username"]
+        assert body["tenant"] == fake_record["tenant"]
+        assert body["scopes"] == fake_record["scopes"]
+
+
+# ── status / identity / capabilities (whole-object contract) ──────
+
+
+class TestDeviceReadEndpoints:
+    async def test_status_returns_entire_status_subobject(self, client):
+        with patch("device_connect_server.portal.views.agent_api.registry_client.get_device",
+                   return_value=SAMPLE_DEVICE):
+            r = await client.get("/api/agent/v1/devices/acme-cam-001/status", headers=H())
+            assert r.status == 200
+            body = await r.json()
+            # KEY ASSERTION: status field is byte-equal with the registry doc.
+            assert body["status"] == SAMPLE_DEVICE["status"]
+            # Includes the extra field a future driver added:
+            assert body["status"]["x_some_new_status_field"] == "added-by-newer-driver"
+            assert body["device_id"] == "acme-cam-001"
+
+    async def test_identity_returns_entire_identity_subobject(self, client):
+        with patch("device_connect_server.portal.views.agent_api.registry_client.get_device",
+                   return_value=SAMPLE_DEVICE):
+            r = await client.get("/api/agent/v1/devices/acme-cam-001/identity", headers=H())
+            assert r.status == 200
+            body = await r.json()
+            assert body["identity"] == SAMPLE_DEVICE["identity"]
+            assert body["identity"]["x_custom_extra_field"] == "registry-added-later"
+
+    async def test_capabilities_returns_functions_and_events(self, client):
+        with patch("device_connect_server.portal.views.agent_api.registry_client.get_device",
+                   return_value=SAMPLE_DEVICE):
+            r = await client.get(
+                "/api/agent/v1/devices/acme-cam-001/capabilities", headers=H())
+            assert r.status == 200
+            body = await r.json()
+            assert body["capabilities"]["functions"] == SAMPLE_DEVICE["capabilities"]["functions"]
+            assert body["capabilities"]["events"] == SAMPLE_DEVICE["capabilities"]["events"]
+
+    async def test_functions_endpoint_byte_equal_with_capabilities_subarray(self, client):
+        with patch("device_connect_server.portal.views.agent_api.registry_client.get_device",
+                   return_value=SAMPLE_DEVICE):
+            r = await client.get(
+                "/api/agent/v1/devices/acme-cam-001/functions", headers=H())
+            body = await r.json()
+            assert body["functions"] == SAMPLE_DEVICE["capabilities"]["functions"]
+
+    async def test_events_endpoint_byte_equal_with_capabilities_subarray(self, client):
+        with patch("device_connect_server.portal.views.agent_api.registry_client.get_device",
+                   return_value=SAMPLE_DEVICE):
+            r = await client.get(
+                "/api/agent/v1/devices/acme-cam-001/events", headers=H())
+            body = await r.json()
+            assert body["events"] == SAMPLE_DEVICE["capabilities"]["events"]
+
+    async def test_get_returns_whole_doc(self, client):
+        with patch("device_connect_server.portal.views.agent_api.registry_client.get_device",
+                   return_value=SAMPLE_DEVICE):
+            r = await client.get("/api/agent/v1/devices/acme-cam-001", headers=H())
+            assert r.status == 200
+            body = await r.json()
+            assert body == SAMPLE_DEVICE
+
+    async def test_not_found_is_json_404(self, client):
+        with patch("device_connect_server.portal.views.agent_api.registry_client.get_device",
+                   return_value=None):
+            r = await client.get("/api/agent/v1/devices/missing/status", headers=H())
+            assert r.status == 404
+            body = await r.json()
+            assert body["error"]["code"] == "not_found"
+
+
+# ── scope enforcement ─────────────────────────────────────────────
+
+
+class TestScopeEnforcement:
+    async def test_invoke_requires_devices_invoke(self, client):
+        # fake_record has only devices:read
+        r = await client.post(
+            "/api/agent/v1/devices/cam-001/invoke", headers=H(),
+            json={"function": "capture"})
+        assert r.status == 403
+        body = await r.json()
+        assert body["error"]["code"] == "missing_scope"
+
+    async def test_provision_requires_devices_provision(self, client):
+        r = await client.post(
+            "/api/agent/v1/devices", headers=H(), json={"device_name": "cam-002"})
+        assert r.status == 403
+        body = await r.json()
+        assert body["error"]["code"] == "missing_scope"
+
+    async def test_stream_requires_events_read(self, client):
+        r = await client.get(
+            "/api/agent/v1/devices/cam-001/events/motion/stream?duration=1",
+            headers=H())
+        assert r.status == 403
+
+
+# ── tenant override ───────────────────────────────────────────────
+
+
+class TestTenantOverride:
+    async def test_non_admin_tenant_override_forbidden(self, client):
+        r = await client.get("/api/agent/v1/fleet?tenant=other", headers=H())
+        assert r.status == 403
+        body = await r.json()
+        assert body["error"]["code"] == "tenant_override_forbidden"
+
+    async def test_admin_tenant_override_allowed(self, admin_client):
+        with patch(
+            "device_connect_server.portal.views.agent_api.registry_client.list_live_devices",
+            return_value=[],
+        ), patch(
+            "device_connect_server.portal.views.agent_api.credentials_svc.list_credentials",
+            return_value=[],
+        ):
+            r = await admin_client.get("/api/agent/v1/fleet?tenant=other", headers=H())
+            assert r.status == 200
+            body = await r.json()
+            assert body["tenant"] == "other"
+
+
+# ── stream argument validation ────────────────────────────────────
+
+
+class TestStreamArgValidation:
+    async def test_stream_requires_a_bound(self, admin_client):
+        r = await admin_client.get(
+            "/api/agent/v1/devices/cam-001/events/motion/stream", headers=H())
+        assert r.status == 400
+        body = await r.json()
+        assert body["error"]["code"] == "missing_bound"
+
+    async def test_stream_rejects_invalid_format(self, admin_client):
+        r = await admin_client.get(
+            "/api/agent/v1/devices/cam-001/events/motion/stream"
+            "?format=xml&duration=1",
+            headers=H())
+        assert r.status == 400
+
+    async def test_stream_rejects_negative_duration(self, admin_client):
+        r = await admin_client.get(
+            "/api/agent/v1/devices/cam-001/events/motion/stream?duration=-1",
+            headers=H())
+        assert r.status == 400

--- a/packages/device-connect-server/tests/device_connect_server/test_portal_agent_api.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portal_agent_api.py
@@ -11,7 +11,6 @@ with the registry document.
 
 from __future__ import annotations
 
-import json
 from unittest.mock import patch
 
 import pytest
@@ -299,3 +298,188 @@ class TestStreamArgValidation:
             "/api/agent/v1/devices/cam-001/events/motion/stream?duration=-1",
             headers=H())
         assert r.status == 400
+
+    async def test_stream_rejects_nats_wildcard_event_name(self, admin_client):
+        # `>` and `*` are NATS subject wildcards. Event names that contain them
+        # would let a caller subscribe to wider subject hierarchies than
+        # intended; validate_name must reject them.
+        r = await admin_client.get(
+            "/api/agent/v1/devices/cam-001/events/%3E/stream?duration=1",
+            headers=H())
+        assert r.status == 400
+        body = await r.json()
+        assert body["error"]["code"] == "invalid_event_name"
+
+
+# ── credentials tenant binding (regression: IDOR fix) ─────────────
+
+
+@pytest.fixture
+def cred_record():
+    """Token in tenant `acme` with the credentials scope."""
+    return {
+        "token_id": "cred0",
+        "username": "alice",
+        "tenant": "acme",
+        "role": "user",
+        "scopes": ["devices:credentials"],
+        "created_at": "2026-05-01T00:00:00+00:00",
+    }
+
+
+@pytest.fixture
+async def cred_client(cred_record):
+    app = _build_app()
+    server = TestServer(app)
+    async with server:
+        async with TestClient(server) as cli:
+            with patch.object(tokens_svc, "verify_token", return_value=cred_record):
+                yield cli
+
+
+class TestCredentialsTenantBinding:
+    """The unprefixed-filename fallback used to leak other tenants' creds when
+    the credential file lacked a `tenant` field. Non-admin requests must
+    fail-closed regardless of whether the file declares a tenant."""
+
+    async def test_non_admin_cannot_read_other_tenant_credential(self, cred_client):
+        # File for another tenant, *with* tenant field set correctly.
+        other = {"tenant": "other", "nats_jwt": "...", "nats_seed": "..."}
+
+        def _get(filename):
+            if filename == "other-cam.creds.json":
+                return other
+            return None
+
+        with patch(
+            "device_connect_server.portal.views.agent_api.credentials_svc.get_credential_data",
+            side_effect=_get,
+        ):
+            r = await cred_client.get(
+                "/api/agent/v1/devices/other-cam/credentials", headers=H())
+            # Either 404 (unprefixed fallback rejected for non-admin)
+            # or 403 (fallback found but tenant mismatch). Never 200.
+            assert r.status in (403, 404)
+
+    async def test_non_admin_blocked_when_cred_file_missing_tenant_field(self, cred_client):
+        # The historical IDOR: cred file has no `tenant` field, fallback used to
+        # return 200 because the truthy guard skipped the binding check.
+        legacy = {"nats_jwt": "...", "nats_seed": "..."}  # no tenant key
+
+        def _get(filename):
+            if filename == "other-cam.creds.json":
+                return legacy
+            return None
+
+        with patch(
+            "device_connect_server.portal.views.agent_api.credentials_svc.get_credential_data",
+            side_effect=_get,
+        ):
+            r = await cred_client.get(
+                "/api/agent/v1/devices/other-cam/credentials", headers=H())
+            assert r.status in (403, 404), (
+                "Non-admin must never receive a credential whose tenant binding "
+                "cannot be verified. Got %d" % r.status
+            )
+
+    async def test_non_admin_can_read_own_tenant_credential(self, cred_client):
+        own = {"tenant": "acme", "nats_jwt": "...", "nats_seed": "..."}
+
+        def _get(filename):
+            if filename == "acme-cam-001.creds.json":
+                return own
+            return None
+
+        with patch(
+            "device_connect_server.portal.views.agent_api.credentials_svc.get_credential_data",
+            side_effect=_get,
+        ):
+            r = await cred_client.get(
+                "/api/agent/v1/devices/cam-001/credentials", headers=H())
+            assert r.status == 200
+            body = await r.json()
+            assert body["result"]["filename"] == "acme-cam-001.creds.json"
+            assert body["result"]["content"]["tenant"] == "acme"
+
+
+# ── invoke timeout cap (regression) ───────────────────────────────
+
+
+@pytest.fixture
+def invoke_record():
+    return {
+        "token_id": "inv0",
+        "username": "alice",
+        "tenant": "acme",
+        "role": "user",
+        "scopes": ["devices:invoke"],
+        "created_at": "2026-05-01T00:00:00+00:00",
+    }
+
+
+@pytest.fixture
+async def invoke_client(invoke_record):
+    app = _build_app()
+    server = TestServer(app)
+    async with server:
+        async with TestClient(server) as cli:
+            with patch.object(tokens_svc, "verify_token", return_value=invoke_record):
+                yield cli
+
+
+class TestInvokeTimeoutCap:
+    async def test_clamps_unbounded_client_timeout(self, invoke_client):
+        # Client tries 1e9 seconds; server must clamp to MAX_INVOKE_TIMEOUT_S.
+        seen = {}
+
+        class _FakeBackend:
+            def backend_name(self): return "test"
+            async def rpc_invoke(self, tenant, full_name, fn, params, timeout):
+                seen["timeout"] = timeout
+                return {"ok": True}
+
+        with patch(
+            "device_connect_server.portal.views.agent_api.get_backend",
+            return_value=_FakeBackend(),
+        ):
+            r = await invoke_client.post(
+                "/api/agent/v1/devices/cam-001/invoke",
+                headers=H(),
+                json={"function": "ping", "timeout": 1e9},
+            )
+            assert r.status == 200
+        assert seen["timeout"] == agent_api.MAX_INVOKE_TIMEOUT_S
+
+
+# ── invoke-with-fallback duplicate device id (regression) ─────────
+
+
+class TestInvokeFallbackDuplicates:
+    async def test_tried_array_correct_with_duplicate_ids(self, invoke_client):
+        # Old code used list.index() which returned the first occurrence,
+        # producing a wrong `tried` array when the same id appeared twice.
+        attempts = []
+
+        class _FakeBackend:
+            def backend_name(self): return "test"
+            async def rpc_invoke(self, tenant, full_name, fn, params, timeout):
+                attempts.append(full_name)
+                if len(attempts) < 3:
+                    raise RuntimeError("boom")
+                return {"ok": True, "attempt": len(attempts)}
+
+        with patch(
+            "device_connect_server.portal.views.agent_api.get_backend",
+            return_value=_FakeBackend(),
+        ):
+            r = await invoke_client.post(
+                "/api/agent/v1/invoke-with-fallback",
+                headers=H(),
+                # Same id appears at index 0 and 2; success on the 3rd attempt.
+                json={"device_ids": ["cam-a", "cam-b", "cam-a"], "function": "ping"},
+            )
+            assert r.status == 200
+            body = await r.json()
+            tried = body["result"]["tried"]
+            assert [t["ok"] for t in tried] == [False, False, True]
+            assert len(tried) == 3

--- a/packages/device-connect-server/tests/device_connect_server/test_portal_tokens.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portal_tokens.py
@@ -4,7 +4,6 @@
 
 """Unit tests for device_connect_server.portal.services.tokens."""
 
-import json
 from unittest.mock import patch
 
 import pytest

--- a/packages/device-connect-server/tests/device_connect_server/test_portal_tokens.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portal_tokens.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for device_connect_server.portal.services.tokens."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from device_connect_server.portal.services import tokens as tokens_svc
+
+
+class _FakeEtcd:
+    """In-memory etcd stub with the get/put/get_prefix surface used by tokens."""
+
+    def __init__(self):
+        self.kv: dict[str, str] = {}
+
+    def get(self, key):
+        v = self.kv.get(key)
+        return [v] if v is not None else []
+
+    def put(self, key, value):
+        self.kv[key] = value
+
+    def get_prefix(self, prefix):
+        out = []
+        for k, v in self.kv.items():
+            if k.startswith(prefix):
+                out.append((v, {"key": k}))
+        return out
+
+
+@pytest.fixture
+def fake_etcd():
+    fake = _FakeEtcd()
+    with patch.object(tokens_svc, "_etcd_client", return_value=fake):
+        yield fake
+
+
+# ── creation ────────────────────────────────────────────────────────
+
+
+class TestCreateToken:
+    def test_returns_token_secret_only_on_create(self, fake_etcd):
+        out = tokens_svc.create_token(
+            username="alice", tenant="acme", role="user",
+            scopes=["devices:read"], label="ci",
+        )
+        assert out["token"].startswith("dcp_")
+        assert out["username"] == "alice"
+        assert out["tenant"] == "acme"
+        assert out["scopes"] == ["devices:read"]
+        # Listing must never expose the secret or its hash
+        listed = tokens_svc.list_tokens()
+        assert listed
+        for r in listed:
+            assert "secret_hash" not in r
+            assert "token" not in r
+
+    def test_unknown_scope_rejected(self, fake_etcd):
+        with pytest.raises(ValueError):
+            tokens_svc.create_token(
+                username="alice", tenant="acme", role="user",
+                scopes=["devices:read", "made:up"],
+            )
+
+    def test_scopes_deduped_and_sorted(self, fake_etcd):
+        out = tokens_svc.create_token(
+            username="a", tenant="t", role="user",
+            scopes=["devices:invoke", "devices:read", "devices:invoke"],
+        )
+        assert out["scopes"] == ["devices:invoke", "devices:read"]
+
+
+# ── verification ────────────────────────────────────────────────────
+
+
+class TestVerifyToken:
+    def test_round_trip(self, fake_etcd):
+        created = tokens_svc.create_token(
+            username="bob", tenant="acme", role="user", scopes=["devices:read"],
+        )
+        verified = tokens_svc.verify_token(created["token"])
+        assert verified is not None
+        assert verified["username"] == "bob"
+        assert verified["scopes"] == ["devices:read"]
+        assert "secret_hash" not in verified
+
+    def test_malformed_token_rejected(self, fake_etcd):
+        assert tokens_svc.verify_token("") is None
+        assert tokens_svc.verify_token("not-a-token") is None
+        assert tokens_svc.verify_token("dcp_only") is None
+        assert tokens_svc.verify_token("dcp_id_") is None
+
+    def test_unknown_id_rejected(self, fake_etcd):
+        assert tokens_svc.verify_token("dcp_aaaaaaaaaaaaaaaa_secret") is None
+
+    def test_wrong_secret_rejected(self, fake_etcd):
+        created = tokens_svc.create_token(
+            username="bob", tenant="acme", role="user", scopes=["devices:read"],
+        )
+        token = created["token"]
+        # Mutate the secret tail
+        head, tail = token.rsplit("_", 1)
+        bad = f"{head}_{tail[:-1]}X"
+        assert tokens_svc.verify_token(bad) is None
+
+    def test_revoked_rejected(self, fake_etcd):
+        created = tokens_svc.create_token(
+            username="bob", tenant="acme", role="user", scopes=["devices:read"],
+        )
+        assert tokens_svc.revoke_token(created["token_id"]) is True
+        assert tokens_svc.verify_token(created["token"]) is None
+
+    def test_expired_rejected(self, fake_etcd):
+        from datetime import datetime, timedelta, timezone
+        past = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        created = tokens_svc.create_token(
+            username="bob", tenant="acme", role="user",
+            scopes=["devices:read"], expires_at=past,
+        )
+        assert tokens_svc.verify_token(created["token"]) is None
+
+
+# ── scope checks ────────────────────────────────────────────────────
+
+
+class TestScopes:
+    def test_has_scope_direct(self):
+        assert tokens_svc.has_scope({"scopes": ["devices:read"]}, "devices:read")
+        assert not tokens_svc.has_scope({"scopes": ["devices:read"]}, "devices:invoke")
+
+    def test_admin_wildcard_grants_admin(self):
+        assert tokens_svc.has_scope({"scopes": ["admin:*"]}, "admin:tenants")
+
+    def test_admin_wildcard_does_not_grant_devices_scope(self):
+        # admin:* covers admin:* family only — explicit devices:* is still required
+        assert not tokens_svc.has_scope({"scopes": ["admin:*"]}, "devices:invoke")
+
+    def test_no_scopes(self):
+        assert not tokens_svc.has_scope({}, "devices:read")

--- a/packages/device-connect-server/tests/device_connect_server/test_portalctl_cli.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portalctl_cli.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dc-portalctl: parser, env handling, output, stream guards."""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from device_connect_server.portalctl import cli as portalctl_cli
+from device_connect_server.portalctl import streaming as portalctl_stream
+
+
+# ── parser ────────────────────────────────────────────────────────
+
+
+class TestParser:
+    def test_top_level_help(self):
+        p = portalctl_cli._build_parser()
+        # All required subcommands wired
+        sub_names = {a.dest for a in p._actions if a.dest}
+        assert "cmd" in sub_names
+
+    def test_devices_status_requires_id(self):
+        p = portalctl_cli._build_parser()
+        with pytest.raises(SystemExit):
+            p.parse_args(["devices", "status"])
+
+    def test_provision_accepts_metadata(self):
+        p = portalctl_cli._build_parser()
+        ns = p.parse_args([
+            "devices", "provision", "cam-001",
+            "--device-type", "camera",
+            "--metadata", "site=lab",
+            "--metadata", "rack=3",
+        ])
+        assert ns.device_name == "cam-001"
+        assert ns.device_type == "camera"
+        assert ns.metadata == ["site=lab", "rack=3"]
+
+
+# ── config resolution ─────────────────────────────────────────────
+
+
+class TestConfigResolution:
+    def test_no_token_errors(self, monkeypatch, capsys):
+        monkeypatch.delenv("DEVICE_CONNECT_PORTAL_TOKEN", raising=False)
+        ns = portalctl_cli._build_parser().parse_args(["auth", "me"])
+        ns.token = None
+        ns.portal_url = None
+        with pytest.raises(SystemExit):
+            portalctl_cli._resolve_config(ns)
+
+    def test_env_token_picked_up(self, monkeypatch):
+        monkeypatch.setenv("DEVICE_CONNECT_PORTAL_TOKEN", "dcp_env_secret")
+        monkeypatch.setenv("DEVICE_CONNECT_PORTAL_URL", "http://h:9000")
+        ns = portalctl_cli._build_parser().parse_args(["auth", "me"])
+        ns.token = None
+        ns.portal_url = None
+        url, token = portalctl_cli._resolve_config(ns)
+        assert url == "http://h:9000"
+        assert token == "dcp_env_secret"
+
+
+# ── exit code mapping ─────────────────────────────────────────────
+
+
+class TestExitCodes:
+    @pytest.mark.parametrize("status,expected", [
+        (200, 0), (201, 0), (204, 0),
+        (401, 4), (403, 5), (404, 6),
+        (400, 1), (500, 1), (502, 1),
+    ])
+    def test_status_to_exit(self, status, expected):
+        assert portalctl_cli._exit_for_status(status, {}) == expected
+
+
+# ── output formatters ─────────────────────────────────────────────
+
+
+class TestOutput:
+    def test_json_output_pretty(self, capsys):
+        portalctl_cli._emit({"k": 1}, "json")
+        out = capsys.readouterr().out
+        # Pretty-printed
+        assert "\n" in out
+        assert json.loads(out) == {"k": 1}
+
+    def test_compact_device_list(self, capsys):
+        portalctl_cli._emit(
+            [{"device_id": "cam-1", "identity": {"device_type": "camera"},
+              "status": {"availability": "available"}}],
+            "compact",
+        )
+        out = capsys.readouterr().out
+        assert "cam-1" in out
+        assert "camera" in out
+        assert "available" in out
+
+
+# ── stream argument guard ─────────────────────────────────────────
+
+
+class TestStreamGuard:
+    def test_stream_without_bound_errors(self, capsys, monkeypatch):
+        monkeypatch.setenv("DEVICE_CONNECT_PORTAL_TOKEN", "dcp_t_s")
+        rc = portalctl_cli.main(["devices", "stream", "cam-1", "motion"])
+        err = capsys.readouterr().err
+        assert rc == 2
+        assert "duration" in err and "count" in err and "follow" in err
+
+
+# ── stream_ndjson termination semantics ──────────────────────────
+
+
+class _FakeBody:
+    def __init__(self, lines: list[bytes]):
+        self._lines = lines
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._lines:
+            raise StopAsyncIteration
+        return self._lines.pop(0)
+
+
+class _FakeResp:
+    def __init__(self, lines, status=200):
+        self.status = status
+        self.content = _FakeBody(lines)
+        self._text = ""
+
+    async def text(self):
+        return self._text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, lines, status=200):
+        self.lines = lines
+        self.status = status
+
+    def get(self, url, headers=None):
+        return _FakeResp(list(self.lines), status=self.status)
+
+
+class TestStreamNdjsonTermination:
+    async def test_stops_on_count(self):
+        lines = [
+            (json.dumps({"event": "motion", "n": 1}) + "\n").encode(),
+            (json.dumps({"event": "motion", "n": 2}) + "\n").encode(),
+            (json.dumps({"event": "motion", "n": 3}) + "\n").encode(),
+        ]
+        session = _FakeSession(lines)
+        out = io.StringIO()
+        rc, events, closed_by = await portalctl_stream.stream_ndjson(
+            session, "http://x", {}, duration=None, count=2, follow=False, out=out,
+        )
+        assert rc == 0
+        assert events == 2
+        assert closed_by == "count"
+        # Should have emitted a _meta trailer locally because the server didn't
+        text = out.getvalue()
+        assert '"_meta"' in text
+
+    async def test_passes_through_server_meta(self):
+        lines = [
+            (json.dumps({"event": "motion", "n": 1}) + "\n").encode(),
+            (json.dumps({"_meta": {"closed_by": "duration",
+                                    "events_received": 1,
+                                    "elapsed_s": 5.0}}) + "\n").encode(),
+        ]
+        out = io.StringIO()
+        session = _FakeSession(lines)
+        rc, events, closed_by = await portalctl_stream.stream_ndjson(
+            session, "http://x", {}, duration=10, count=None, follow=False, out=out,
+        )
+        assert closed_by == "duration"
+        # The first event passed through; trailer printed once (server's)
+        assert out.getvalue().count('"_meta"') == 1
+
+    async def test_no_events_yields_exit_code_2(self):
+        # Empty body, simulate duration close (no events)
+        lines = [
+            (json.dumps({"_meta": {"closed_by": "duration",
+                                    "events_received": 0,
+                                    "elapsed_s": 1.0}}) + "\n").encode(),
+        ]
+        out = io.StringIO()
+        session = _FakeSession(lines)
+        rc, events, closed_by = await portalctl_stream.stream_ndjson(
+            session, "http://x", {}, duration=1, count=None, follow=False, out=out,
+        )
+        assert closed_by == "duration"
+        assert events == 0
+        assert rc == 2
+
+    async def test_http_error_returns_1(self):
+        session = _FakeSession([], status=500)
+        out = io.StringIO()
+        rc, events, closed_by = await portalctl_stream.stream_ndjson(
+            session, "http://x", {}, duration=1, count=None, follow=False, out=out,
+        )
+        assert rc == 1
+        assert events == 0

--- a/packages/device-connect-server/tests/device_connect_server/test_portalctl_cli.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portalctl_cli.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import io
 import json
-from unittest.mock import AsyncMock, patch
 
 import pytest
 


### PR DESCRIPTION
## Summary

End-to-end agent integration for the Device Connect portal. Lets a tenant user hand a fleet to a coding agent (Claude Code / Codex / Cursor / etc.) with a single browser approval click — no copy-paste, no manual CLI install.

Five commits, three layers:

- **Agent API** (`/api/agent/v1/*`, JSON-only, Bearer-authenticated) — fleet, devices, capabilities, provisioning, invocation, bounded event streams.
- **`dc-portalctl` CLI** — auth, fleet, devices, invoke, stream subcommands. Browser-mediated `auth login` mints + caches a token at `~/.config/dc-portalctl/token`.
- **Coding Agents tab** (`/coding-agents`) — downloadable `AGENTS.md` rendered per-tenant (portal URL, NATS host, example device id pre-filled), plus token CRUD (mint with scope checkboxes, list, revoke). The agent itself runs install (in `~/.dc-portalctl/venv`) + `auth login`; the human only clicks Approve once.

Also: `setup_deployment.sh` now fails loudly when the NATS JWT bootstrap is missing instead of crash-looping silently, and the portal package data glob ships non-`.html` templates so AGENTS.md.j2 is included in the wheel.

## Test plan

- [ ] `docker compose -f infra/docker-compose-multitenant-nats.yml up -d --build portal` and sign in as a non-admin user.
- [ ] Visit `/coding-agents` — confirm AGENTS.md downloads with `{{ tenant }}` etc. substituted, no leftover placeholders.
- [ ] Mint a token (label + scopes) — confirm one-time secret panel + copy button; confirm row appears in the list.
- [ ] `curl -H "Authorization: Bearer dcp_…" $PORTAL_URL/api/agent/v1/me` returns identity + scopes; revoke → 401.
- [ ] Cross-user IDOR check: forge a revoke POST against another user's token id → 403/404, target token still active.
- [ ] `dc-portalctl auth login` against a fresh checkout, then `dc-portalctl fleet describe` and `dc-portalctl devices list` — both succeed.
- [ ] Bounded stream: `dc-portalctl devices stream <id> <event> --duration 30 --count 5 --format ndjson` returns `_meta` trailer.
- [ ] `ruff check packages/device-connect-server/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)