### PR TITLE
edge: support lifecycle event subscriptions and glob device_id filters

### DIFF
--- a/examples/peer-lifecycle/device_a.py
+++ b/examples/peer-lifecycle/device_a.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""device-a -- the device that goes offline in the peer-lifecycle demo.
+
+Just heartbeats so the registry tracks it. When this process is killed,
+the registry's offline_monitor will publish a `device-connect.<tenant>.device.offline`
+event after the heartbeat TTL expires (default ~15s).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+
+from device_connect_edge import DeviceRuntime
+from device_connect_edge.drivers import DeviceDriver, rpc
+from device_connect_edge.types import DeviceIdentity
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s  device-a  %(levelname)-7s  %(message)s")
+log = logging.getLogger("device-a")
+
+
+class DeviceADriver(DeviceDriver):
+    device_type = "demo_device"
+
+    @property
+    def identity(self) -> DeviceIdentity:
+        return DeviceIdentity(
+            device_type="demo_device",
+            description="Demo device A -- goes offline to trigger peer_lost",
+        )
+
+    @rpc()
+    async def ping(self) -> dict:
+        return {"ok": True}
+
+    async def connect(self) -> None:
+        log.info("connected")
+
+    async def disconnect(self) -> None:
+        log.info("disconnecting")
+
+
+def _resolve_messaging_urls() -> list[str]:
+    zenoh = os.environ.get("ZENOH_CONNECT")
+    if zenoh:
+        return [u.strip() for u in zenoh.split(",") if u.strip()]
+    return [os.environ.get("NATS_URL", "nats://localhost:4222")]
+
+
+async def main() -> None:
+    urls = _resolve_messaging_urls()
+    allow_insecure = os.environ.get("DEVICE_CONNECT_ALLOW_INSECURE", "true").lower() in (
+        "1", "true", "yes",
+    )
+    device = DeviceRuntime(
+        driver=DeviceADriver(),
+        device_id="device-a",
+        messaging_urls=urls,
+        allow_insecure=allow_insecure,
+    )
+
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+    for s in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(s, stop.set)
+
+    log.info("=" * 56)
+    log.info(" device-a   broker=%s", urls)
+    log.info(" Kill me to trigger device-b's peer_lost handler.")
+    log.info("=" * 56)
+
+    task = asyncio.create_task(device.run())
+    await stop.wait()
+    await device.stop()
+    if not task.done():
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/peer-lifecycle/device_b.py
+++ b/examples/peer-lifecycle/device_b.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""device-b -- watches device-a, emits `black_out` when its peer goes offline.
+
+Demonstrates the lifecycle subscription added in feat/peer-lifecycle-events:
+
+    @on(device_id="device-a", event_name="peer_lost")
+
+Subscribes to the registry's `device-connect.<tenant>.device.offline`
+subject, filters by `device_id` post-hoc (since the subject is shared
+per tenant), and reacts.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+
+from device_connect_edge import DeviceRuntime
+from device_connect_edge.drivers import DeviceDriver, emit
+from device_connect_edge.drivers.base import on
+from device_connect_edge.types import DeviceIdentity
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s  device-b  %(levelname)-7s  %(message)s")
+log = logging.getLogger("device-b")
+
+
+class DeviceBDriver(DeviceDriver):
+    device_type = "demo_device"
+
+    @property
+    def identity(self) -> DeviceIdentity:
+        return DeviceIdentity(
+            device_type="demo_device",
+            description="Demo device B -- reacts to A's disappearance",
+        )
+
+    @on(device_id="device-a", event_name="peer_lost")
+    async def on_peer_a_lost(self, device_id, event_name, payload):
+        log.warning("peer LOST: %s   payload=%s", device_id, payload)
+        await self.black_out(reason=f"peer {device_id} went offline")
+
+    @emit()
+    async def black_out(self, reason: str):
+        """Emitted when the demo's peer dependency drops."""
+        # Body is pre-emit hook -- the @emit decorator handles publication.
+        log.info(">>> emitting black_out: %s", reason)
+
+    async def connect(self) -> None:
+        log.info("connected, waiting for device-a peer_lost")
+
+    async def disconnect(self) -> None:
+        log.info("disconnecting")
+
+
+def _resolve_messaging_urls() -> list[str]:
+    zenoh = os.environ.get("ZENOH_CONNECT")
+    if zenoh:
+        return [u.strip() for u in zenoh.split(",") if u.strip()]
+    return [os.environ.get("NATS_URL", "nats://localhost:4222")]
+
+
+async def main() -> None:
+    urls = _resolve_messaging_urls()
+    allow_insecure = os.environ.get("DEVICE_CONNECT_ALLOW_INSECURE", "true").lower() in (
+        "1", "true", "yes",
+    )
+    device = DeviceRuntime(
+        driver=DeviceBDriver(),
+        device_id="device-b",
+        messaging_urls=urls,
+        allow_insecure=allow_insecure,
+    )
+
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+    for s in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(s, stop.set)
+
+    log.info("=" * 56)
+    log.info(" device-b   broker=%s   watching=device-a", urls)
+    log.info("=" * 56)
+
+    task = asyncio.create_task(device.run())
+    await stop.wait()
+    await device.stop()
+    if not task.done():
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/device-connect-edge/device_connect_edge/drivers/base.py
+++ b/packages/device-connect-edge/device_connect_edge/drivers/base.py
@@ -66,6 +66,7 @@ Example:
 from __future__ import annotations
 
 import asyncio
+import fnmatch
 import json
 import logging
 import time
@@ -1088,6 +1089,34 @@ class DeviceDriver(ABC):
                     name, sub.get("device_type"), sub.get("event_name"), e,
                 )
 
+    # Lifecycle event aliases. The registry service publishes presence
+    # changes to `device-connect.<tenant>.device.{online,offline}` (a
+    # single subject per tenant -- the device_id is in the payload, not
+    # the subject). These aliases let drivers subscribe with a familiar
+    # name; both the canonical and alias forms are accepted.
+    _LIFECYCLE_ALIAS_TO_CANONICAL: Dict[str, str] = {
+        "peer_present":   "device.online",
+        "peer_lost":      "device.offline",
+        "device.online":  "device.online",
+        "device.offline": "device.offline",
+    }
+
+    @staticmethod
+    def _device_id_matches(filter_pattern: Optional[str], source_id: str) -> bool:
+        """True when source_id matches the @on(device_id=...) filter.
+
+        - None / empty pattern matches everything.
+        - A pattern with glob characters (*, ?, [) is matched with fnmatch
+          (case-sensitive). e.g. `interlock-*` matches `interlock-01`,
+          `rack-?-laser` matches `rack-A-laser`.
+        - Otherwise an exact string equality.
+        """
+        if not filter_pattern:
+            return True
+        if any(c in filter_pattern for c in "*?["):
+            return fnmatch.fnmatchcase(source_id, filter_pattern)
+        return source_id == filter_pattern
+
     async def _setup_subscription(self, sub: Dict[str, Any]) -> None:
         """Set up a single event subscription.
 
@@ -1099,27 +1128,42 @@ class DeviceDriver(ABC):
         event_name = sub.get("event_name")
         handler = sub["handler"]
 
-        # Build subscription pattern
-        # Pattern: device-connect.{tenant}.{device_pattern}.event.{event_pattern}
-        # NOTE: NATS wildcards (*) only work at token boundaries (between dots).
-        # We can't do "robot-*" to match "robot-001" - must use "*" and filter.
-        if device_id:
-            device_pattern = device_id
-        else:
-            # Use wildcard for all devices, filter by device_type in handler
-            device_pattern = "*"
-
-        event_pattern = event_name if event_name else "*"
-
-        # Clean event name (remove "event/" prefix if present)
-        if event_pattern.startswith("event/"):
-            event_pattern = event_pattern[6:]
-
-        # Get tenant from router
         tenant = getattr(self._router, "_tenant", "default")
-        subject = f"device-connect.{tenant}.{device_pattern}.event.{event_pattern}"
-
         self_id = getattr(self, "_device_id", None) or "unknown"
+
+        # Lifecycle events are published by the registry on a shared
+        # subject per tenant; route them differently from per-device
+        # event subscriptions.
+        canonical_lifecycle = self._LIFECYCLE_ALIAS_TO_CANONICAL.get(event_name or "")
+        is_lifecycle = canonical_lifecycle is not None
+
+        # device_id may be a glob pattern (`interlock-*`, `rack-?-laser`).
+        # The broker's wildcard is single-token only and lives between
+        # dots, so for glob patterns we subscribe to `*` at the broker
+        # and filter post-hoc with fnmatch in the message handler.
+        device_id_is_glob = bool(device_id) and any(c in device_id for c in "*?[")
+
+        if is_lifecycle:
+            subject = f"device-connect.{tenant}.{canonical_lifecycle}"
+        else:
+            # Build per-device subscription pattern
+            # Pattern: device-connect.{tenant}.{device_pattern}.event.{event_pattern}
+            if not device_id or device_id_is_glob:
+                # No device_id, or a glob -- subscribe to broker wildcard
+                # and filter in-process. Filter by device_type or device_id
+                # glob applied in the handler.
+                device_pattern = "*"
+            else:
+                device_pattern = device_id
+
+            event_pattern = event_name if event_name else "*"
+
+            # Clean event name (remove "event/" prefix if present)
+            if event_pattern.startswith("event/"):
+                event_pattern = event_pattern[6:]
+
+            subject = f"device-connect.{tenant}.{device_pattern}.event.{event_pattern}"
+
         logger.info("[%s] Subscribing to: %s", self_id, subject)
 
         # Use subscribe_with_subject to get the matched subject in callback
@@ -1129,23 +1173,42 @@ class DeviceDriver(ABC):
         async def message_handler(data: bytes, matched_subject: str, _reply: Optional[str]):
             try:
                 parsed = json.loads(data.decode())
-                # Extract device_id from subject: device-connect.{tenant}.{device_id}.event.{event}
-                # Zenoh delivers key expressions with slashes; NATS uses dots — handle both.
-                sep = "/" if "/" in matched_subject else "."
-                parts = matched_subject.split(sep)
-                # Parse from the end for robustness: {prefix}.{tenant}.{device_id}.event.{name}
-                # This handles device IDs that might contain the separator.
-                if len(parts) >= 5 and parts[-2] == "event":
-                    source_device_id = sep.join(parts[2:-2])
-                elif len(parts) > 2:
-                    source_device_id = parts[2]
-                else:
-                    source_device_id = "unknown"
-                source_event_name = parsed.get("method", event_name)
                 payload = parsed.get("params", {})
 
-                # Filter by device_type if specified
-                if device_type:
+                if is_lifecycle:
+                    # Lifecycle subjects are shared across all devices in
+                    # the tenant; the device_id lives in the payload.
+                    source_device_id = payload.get("device_id", "unknown")
+                    source_event_name = canonical_lifecycle
+                else:
+                    # Extract device_id from subject: device-connect.{tenant}.{device_id}.event.{event}
+                    # Zenoh delivers key expressions with slashes; NATS uses dots — handle both.
+                    sep = "/" if "/" in matched_subject else "."
+                    parts = matched_subject.split(sep)
+                    # Parse from the end for robustness: {prefix}.{tenant}.{device_id}.event.{name}
+                    # This handles device IDs that might contain the separator.
+                    if len(parts) >= 5 and parts[-2] == "event":
+                        source_device_id = sep.join(parts[2:-2])
+                    elif len(parts) > 2:
+                        source_device_id = parts[2]
+                    else:
+                        source_device_id = "unknown"
+                    source_event_name = parsed.get("method", event_name)
+
+                # device_id filter (exact or glob). Always applied post-hoc:
+                # - lifecycle subjects don't encode the source device_id
+                # - glob device_id patterns can't be expressed at the broker
+                # Exact-match per-device subscriptions are already filtered
+                # at the broker, so this is a no-op for them.
+                if not self._device_id_matches(device_id, source_device_id):
+                    return
+
+                # Filter by device_type if specified.
+                # Skipped for lifecycle events: the registry publishes
+                # offline before the D2D peer cache forgets the device,
+                # but we don't want to depend on that ordering. Callers
+                # that need type filtering can do it inside the handler.
+                if device_type and not is_lifecycle:
                     # Try to resolve type from D2D peer cache
                     source_type = ""
                     collector = getattr(self._device, '_d2d_collector', None) if self._device else None

--- a/packages/device-connect-edge/tests/test_drivers.py
+++ b/packages/device-connect-edge/tests/test_drivers.py
@@ -360,3 +360,218 @@ class TestSetupSubscriptionsErrorIsolation:
         assert mock_messaging.subscribe_with_subject.await_count == 2
         # Only the second (successful) subscription was tracked
         assert len(driver._subscriptions) == 1
+
+
+# ── lifecycle subscriptions (device.online / device.offline) ──────
+
+class TestLifecycleSubscriptions:
+    """The registry publishes presence changes on a shared subject per
+    tenant: `device-connect.<tenant>.device.{online,offline}`. Drivers
+    use @on(event_name=...) to subscribe; both canonical names and
+    `peer_present`/`peer_lost` aliases must work."""
+
+    async def _setup_capture(self, driver):
+        """Wire driver to a fake router; return the captured subject + handler."""
+        captured = {}
+
+        async def fake_subscribe(subject, callback, **kwargs):
+            captured["subject"] = subject
+            captured["callback"] = callback
+            return MagicMock()
+
+        mock_messaging = AsyncMock()
+        mock_messaging.subscribe_with_subject = AsyncMock(side_effect=fake_subscribe)
+
+        class FakeRouter:
+            def __init__(self):
+                self._messaging = mock_messaging
+                self._tenant = "beta"
+
+        driver._router = FakeRouter()
+        await driver.setup_subscriptions()
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_device_offline_subscribes_to_lifecycle_subject(self):
+        seen = []
+
+        class MyDriver(DeviceDriver):
+            device_type = "test"
+
+            @on(event_name="device.offline")
+            async def on_lost(self, device_id, event_name, payload):
+                seen.append((device_id, event_name, payload))
+
+            async def connect(self): pass
+            async def disconnect(self): pass
+
+        driver = MyDriver()
+        captured = await self._setup_capture(driver)
+
+        # Subscribed to the registry's lifecycle subject, not to a
+        # per-device .event.<name> subject.
+        assert captured["subject"] == "device-connect.beta.device.offline"
+
+        # Simulate a registry-published offline event.
+        import json
+        msg = json.dumps({
+            "jsonrpc": "2.0",
+            "method": "device/offline",
+            "params": {"device_id": "interlock-01", "ts": "2026-05-06T00:00:00Z"},
+        }).encode()
+        await captured["callback"](msg, captured["subject"], None)
+
+        assert seen == [(
+            "interlock-01",
+            "device.offline",
+            {"device_id": "interlock-01", "ts": "2026-05-06T00:00:00Z"},
+        )]
+
+    @pytest.mark.asyncio
+    async def test_peer_lost_alias_resolves_to_offline_subject(self):
+        class MyDriver(DeviceDriver):
+            device_type = "test"
+
+            @on(event_name="peer_lost")
+            async def on_peer_lost(self, device_id, event_name, payload):
+                pass
+
+            async def connect(self): pass
+            async def disconnect(self): pass
+
+        driver = MyDriver()
+        captured = await self._setup_capture(driver)
+        assert captured["subject"] == "device-connect.beta.device.offline"
+
+    @pytest.mark.asyncio
+    async def test_peer_present_alias_resolves_to_online_subject(self):
+        class MyDriver(DeviceDriver):
+            device_type = "test"
+
+            @on(event_name="peer_present")
+            async def on_peer_present(self, device_id, event_name, payload):
+                pass
+
+            async def connect(self): pass
+            async def disconnect(self): pass
+
+        driver = MyDriver()
+        captured = await self._setup_capture(driver)
+        assert captured["subject"] == "device-connect.beta.device.online"
+
+    @pytest.mark.asyncio
+    async def test_device_id_filter_drops_other_devices(self):
+        seen = []
+
+        class MyDriver(DeviceDriver):
+            device_type = "test"
+
+            @on(device_id="interlock-01", event_name="peer_lost")
+            async def on_lost(self, device_id, event_name, payload):
+                seen.append(device_id)
+
+            async def connect(self): pass
+            async def disconnect(self): pass
+
+        driver = MyDriver()
+        captured = await self._setup_capture(driver)
+
+        import json
+        # An unrelated device dropping out -- handler should NOT fire.
+        unrelated = json.dumps({
+            "method": "device/offline",
+            "params": {"device_id": "camera-99"},
+        }).encode()
+        await captured["callback"](unrelated, captured["subject"], None)
+        assert seen == []
+
+        # The device the handler cares about -- handler fires.
+        target = json.dumps({
+            "method": "device/offline",
+            "params": {"device_id": "interlock-01"},
+        }).encode()
+        await captured["callback"](target, captured["subject"], None)
+        assert seen == ["interlock-01"]
+
+    @pytest.mark.asyncio
+    async def test_per_device_event_path_unchanged(self):
+        """Non-lifecycle events still build the per-device subject."""
+
+        class MyDriver(DeviceDriver):
+            device_type = "test"
+
+            @on(device_id="cam-001", event_name="motion_detected")
+            async def on_motion(self, device_id, event_name, payload):
+                pass
+
+            async def connect(self): pass
+            async def disconnect(self): pass
+
+        driver = MyDriver()
+        captured = await self._setup_capture(driver)
+        assert captured["subject"] == "device-connect.beta.cam-001.event.motion_detected"
+
+    @pytest.mark.asyncio
+    async def test_glob_device_id_lifecycle_filters_in_handler(self):
+        """device_id='interlock-*' on lifecycle: subscribe to shared
+        subject, filter by fnmatch in the handler."""
+        seen = []
+
+        class MyDriver(DeviceDriver):
+            device_type = "test"
+
+            @on(device_id="interlock-*", event_name="peer_lost")
+            async def on_lost(self, device_id, event_name, payload):
+                seen.append(device_id)
+
+            async def connect(self): pass
+            async def disconnect(self): pass
+
+        driver = MyDriver()
+        captured = await self._setup_capture(driver)
+        assert captured["subject"] == "device-connect.beta.device.offline"
+
+        import json
+        for did, should_match in [
+            ("interlock-01", True),
+            ("interlock-99", True),
+            ("laser-01",     False),
+            ("interlock",    False),  # no suffix, glob requires at least one char after the dash
+        ]:
+            msg = json.dumps({
+                "method": "device/offline",
+                "params": {"device_id": did},
+            }).encode()
+            await captured["callback"](msg, captured["subject"], None)
+
+        assert seen == ["interlock-01", "interlock-99"]
+
+    @pytest.mark.asyncio
+    async def test_glob_device_id_per_device_uses_broker_wildcard(self):
+        """device_id='cam-*' on a non-lifecycle event subscribes to
+        the broker-wildcard subject and filters in the handler."""
+        seen = []
+
+        class MyDriver(DeviceDriver):
+            device_type = "test"
+
+            @on(device_id="cam-*", event_name="motion")
+            async def on_motion(self, device_id, event_name, payload):
+                seen.append(device_id)
+
+            async def connect(self): pass
+            async def disconnect(self): pass
+
+        driver = MyDriver()
+        captured = await self._setup_capture(driver)
+        # Glob -> broker wildcard, not the literal pattern.
+        assert captured["subject"] == "device-connect.beta.*.event.motion"
+
+        import json
+        msg_body = json.dumps({"method": "motion", "params": {}}).encode()
+        # Simulate broker delivering events from three different devices.
+        for did in ("cam-001", "cam-rear", "robot-7"):
+            await captured["callback"](
+                msg_body, f"device-connect.beta.{did}.event.motion", None,
+            )
+        assert seen == ["cam-001", "cam-rear"]


### PR DESCRIPTION
Closes #26.

## What changes

The registry already publishes `device-connect.<tenant>.device.{online,offline}` on a shared per-tenant subject. This PR teaches `@on` to subscribe to those — drivers can now react to peers appearing and disappearing through the same decorator they already use, without polling or invoke timeouts.

Also adds glob support to `device_id=` filters: NATS/Zenoh single-token wildcards can't express sub-token patterns like `interlock-*`, so glob patterns subscribe to the broker single-token wildcard and filter post-hoc with `fnmatch`.

```python
# react when a specific peer drops
@on(device_id="interlock-01", event_name="peer_lost")
async def on_interlock_lost(self, device_id, event_name, payload):
    await self.set_power(0.0)

# react when ANY interlock-class peer drops
@on(device_id="interlock-*", event_name="peer_lost")
async def on_any_interlock_lost(self, device_id, event_name, payload):
    await self.set_power(0.0)
```

Per-device `.event.<name>` subscriptions are byte-identical; existing `@on` users see no behavior change.

## Files

- `device_connect_edge/drivers/base.py` — lifecycle subject routing, glob filter, `_device_id_matches()` helper, `_LIFECYCLE_ALIAS_TO_CANONICAL` map.
- `tests/test_drivers.py` — `TestLifecycleSubscriptions`: 7 new tests covering subject routing, alias mapping, exact + glob `device_id` filter, per-device regression check, glob-on-per-device-events.
- `examples/peer-lifecycle/device_{a,b}.py` — 2-device runnable demo.

## Tests

```
30 passed, 0 failed   (23 existing + 7 new)
```

## End-to-end verification

| Path | NATS | Zenoh |
|---|---|---|
| Lifecycle subject routing | ✅ | ✅ |
| Exact `device_id=` filter | ✅ | ✅ |
| Glob `device_id="device-*"` (caught 2 peers) | ✅ | not run, same code path |

NATS run, glob filter:
```
13:56:46  killed device-a AND device-c
13:57:01  device-b: peer LOST: device-a   ->  black_out
13:57:02  device-b: peer LOST: device-c   ->  black_out
```

## Known follow-ups (separate PRs)

- `device_type=` filter for lifecycle events — needs ~5 LOC server-side change to include `device_type` in the registry's lifecycle event payload. Skipped here because relying on the D2D peer cache mid-offline is racy.
- `tag=` filter — needs a new `DeviceIdentity.tags` field; bigger API change.