### PR TITLE
tests: fix flaky test_multiple_sensors[zenoh]

### DIFF
--- a/tests/tests/test_sensor_device.py
+++ b/tests/tests/test_sensor_device.py
@@ -151,18 +151,32 @@ async def test_sensor_capabilities(device_spawner, messaging_url):
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_multiple_sensors(device_spawner, messaging_url):
-    """Multiple sensors should coexist."""
+    """Multiple sensors should coexist.
+
+    Replaces the previous single fixed-sleep settle with a poll-until-both-
+    visible loop. SETTLE_TIME=0.5s is too tight for Zenoh D2D peer
+    convergence under CI load — both peers' presence announcements need to
+    propagate before discover_devices() sees them, and which one arrives
+    first is non-deterministic.
+    """
     _, _ = await device_spawner.spawn_sensor("itest-sensor-a")
     _, _ = await device_spawner.spawn_sensor("itest-sensor-b")
     await asyncio.sleep(SETTLE_TIME)
 
     from device_connect_agent_tools import connect, disconnect, discover_devices
 
+    expected = {"itest-sensor-a", "itest-sensor-b"}
     await asyncio.to_thread(connect, nats_url=messaging_url)
     try:
-        devices = await asyncio.to_thread(discover_devices)
-        ids = [d["device_id"] for d in devices]
-        assert "itest-sensor-a" in ids
-        assert "itest-sensor-b" in ids
+        deadline = asyncio.get_event_loop().time() + 10.0
+        ids: set[str] = set()
+        while asyncio.get_event_loop().time() < deadline:
+            devices = await asyncio.to_thread(discover_devices, refresh=True)
+            ids = {d["device_id"] for d in devices}
+            if expected <= ids:
+                break
+            await asyncio.sleep(0.5)
+        assert "itest-sensor-a" in ids, f"sensor-a not in {ids}"
+        assert "itest-sensor-b" in ids, f"sensor-b not in {ids}"
     finally:
         await asyncio.to_thread(disconnect)


### PR DESCRIPTION
## Summary

- Replace the single fixed-sleep + single `discover_devices` call with a poll-until-both-visible loop (10s deadline, 0.5s between polls, `refresh=True` to bypass the 30s agent-tools cache).
- Keeps the same assertion — just gives zenoh's D2D peer convergence room to complete under CI load.

## Why

Pre-existing flake. Most recently hit in [run 25714029959](https://github.com/arm/device-connect/actions/runs/25714029959) on `cb638b7`, and again in [run 25718459191](https://github.com/arm/device-connect/actions/runs/25718459191) on the same commit (missing sensor varies between runs, classic race).

Root cause is in `PresenceCollector.wait_for_peers` (`discovery.py:315`): it returns as soon as `len(peers) >= 1`. When the agent-tools collector wakes during its 0.25s poll window, sensor-a is in the table but sensor-b's first announcement hasn't been processed yet — so `discover_devices` returns just one peer. The test then asserts on a stale snapshot.

This commit is cherry-picked from `6d8aa87` on the `agent-dispatch-example` branch, which never landed.

## Test plan

- [ ] CI passes integration suite, including `test_multiple_sensors[zenoh]`
- [ ] No change to test scope — both sensors must still be visible