### PR TITLE
edge: D2D parity for peer lifecycle @on handlers

### DIFF
--- a/packages/device-connect-edge/device_connect_edge/discovery.py
+++ b/packages/device-connect-edge/device_connect_edge/discovery.py
@@ -175,11 +175,11 @@ class PresenceCollector:
         messaging,
         tenant: str,
         on_new_peer: Optional[Callable[[str], Any]] = None,
+        on_peer_removed: Optional[Callable[[str], Any]] = None,
         device_id: str = "",
     ):
         self._messaging = messaging
         self._tenant = tenant
-        self._on_new_peer = on_new_peer
         self._device_id = device_id
         self._log_tag = f"D2D [{device_id}]" if device_id else "D2D"
         self._peers: Dict[str, dict] = {}
@@ -187,6 +187,66 @@ class PresenceCollector:
         self._sub = None
         self._prune_task: Optional[asyncio.Task] = None
         self._started = False
+        # Listener lists -- multiple callbacks per lifecycle event.
+        # The constructor-form callbacks seed the lists for backward
+        # compat with the single-listener pattern. Additional listeners
+        # (e.g. @on(event_name="peer_lost") handlers) attach via
+        # add_on_new_peer / add_on_peer_removed.
+        self._new_peer_listeners: List[Callable[[str], Any]] = []
+        self._peer_removed_listeners: List[Callable[[str], Any]] = []
+        if on_new_peer is not None:
+            self._new_peer_listeners.append(on_new_peer)
+        if on_peer_removed is not None:
+            self._peer_removed_listeners.append(on_peer_removed)
+
+    # Backward-compat aliases. Reading from `_on_new_peer` returns the
+    # first registered listener (or None); assigning replaces it. This
+    # preserves the existing device.py pattern of
+    # `collector._on_new_peer = lambda ...`.
+    @property
+    def _on_new_peer(self) -> Optional[Callable[[str], Any]]:
+        return self._new_peer_listeners[0] if self._new_peer_listeners else None
+
+    @_on_new_peer.setter
+    def _on_new_peer(self, cb: Optional[Callable[[str], Any]]) -> None:
+        if cb is None:
+            self._new_peer_listeners = []
+        elif self._new_peer_listeners:
+            self._new_peer_listeners[0] = cb
+        else:
+            self._new_peer_listeners.append(cb)
+
+    def add_on_new_peer(self, cb: Callable[[str], Any]) -> None:
+        """Register an additional callback for new-peer events."""
+        self._new_peer_listeners.append(cb)
+
+    def add_on_peer_removed(self, cb: Callable[[str], Any]) -> None:
+        """Register a callback for peer-removed events (graceful + timeout)."""
+        self._peer_removed_listeners.append(cb)
+
+    async def _emit_new_peer(self, device_id: str) -> None:
+        for cb in list(self._new_peer_listeners):
+            try:
+                result = cb(device_id)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                logger.warning(
+                    "on_new_peer callback failed for device %s",
+                    device_id, exc_info=True,
+                )
+
+    async def _emit_peer_removed(self, device_id: str) -> None:
+        for cb in list(self._peer_removed_listeners):
+            try:
+                result = cb(device_id)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                logger.warning(
+                    "on_peer_removed callback failed for device %s",
+                    device_id, exc_info=True,
+                )
 
     async def start(self) -> None:
         if self._started:
@@ -233,6 +293,7 @@ class PresenceCollector:
                 removed = self._peers.pop(device_id, None)
             if removed:
                 logger.info("%s: peer %s departed gracefully", self._log_tag, device_id)
+                await self._emit_peer_removed(device_id)
             return
 
         payload["_last_seen"] = time.time()
@@ -243,13 +304,7 @@ class PresenceCollector:
 
         if is_new:
             logger.info("%s: discovered peer %s", self._log_tag, device_id)
-            if self._on_new_peer:
-                try:
-                    result = self._on_new_peer(device_id)
-                    if inspect.isawaitable(result):
-                        await result
-                except Exception:
-                    logger.warning("on_new_peer callback failed for device %s", device_id, exc_info=True)
+            await self._emit_new_peer(device_id)
 
     async def _prune_loop(self) -> None:
         try:
@@ -264,6 +319,8 @@ class PresenceCollector:
                     for did in stale:
                         del self._peers[did]
                         logger.info("%s: peer %s timed out", self._log_tag, did)
+                for did in stale:
+                    await self._emit_peer_removed(did)
         except asyncio.CancelledError:
             raise
 

--- a/packages/device-connect-edge/device_connect_edge/drivers/base.py
+++ b/packages/device-connect-edge/device_connect_edge/drivers/base.py
@@ -1117,6 +1117,38 @@ class DeviceDriver(ABC):
             return fnmatch.fnmatchcase(source_id, filter_pattern)
         return source_id == filter_pattern
 
+    async def _setup_lifecycle_d2d(
+        self,
+        collector,
+        canonical_lifecycle: str,
+        device_id_filter: Optional[str],
+        handler: Callable,
+    ) -> None:
+        """Route a lifecycle @on handler through PresenceCollector callbacks.
+
+        D2D mode has no registry publishing device.{online,offline}, so
+        we deliver the same logical event by subscribing to the
+        collector's per-peer add/remove notifications.
+        """
+        self_id = getattr(self, "_device_id", None) or "unknown"
+        logger.info(
+            "[%s] D2D lifecycle subscription: %s (filter=%s)",
+            self_id, canonical_lifecycle, device_id_filter,
+        )
+
+        async def deliver(source_device_id: str) -> None:
+            if not self._device_id_matches(device_id_filter, source_device_id):
+                return
+            try:
+                await handler(source_device_id, canonical_lifecycle, {})
+            except Exception as e:
+                logger.error("Error in D2D lifecycle handler: %s", e)
+
+        if canonical_lifecycle == "device.online":
+            collector.add_on_new_peer(deliver)
+        else:  # "device.offline"
+            collector.add_on_peer_removed(deliver)
+
     async def _setup_subscription(self, sub: Dict[str, Any]) -> None:
         """Set up a single event subscription.
 
@@ -1136,6 +1168,20 @@ class DeviceDriver(ABC):
         # event subscriptions.
         canonical_lifecycle = self._LIFECYCLE_ALIAS_TO_CANONICAL.get(event_name or "")
         is_lifecycle = canonical_lifecycle is not None
+
+        # D2D mode: lifecycle events come from the PresenceCollector
+        # (no registry to publish device.online/offline). Route the
+        # handler through the collector's callbacks; per-device event
+        # subscriptions still go through the broker.
+        d2d_collector = (
+            getattr(self._device, "_d2d_collector", None)
+            if (is_lifecycle and self._device is not None) else None
+        )
+        if is_lifecycle and d2d_collector is not None:
+            await self._setup_lifecycle_d2d(
+                d2d_collector, canonical_lifecycle, device_id, handler,
+            )
+            return
 
         # device_id may be a glob pattern (`interlock-*`, `rack-?-laser`).
         # The broker's wildcard is single-token only and lives between

--- a/packages/device-connect-edge/tests/test_drivers.py
+++ b/packages/device-connect-edge/tests/test_drivers.py
@@ -575,3 +575,282 @@ class TestLifecycleSubscriptions:
                 msg_body, f"device-connect.beta.{did}.event.motion", None,
             )
         assert seen == ["cam-001", "cam-rear"]
+
+
+class TestLifecycleSubscriptionsD2D:
+    """D2D mode has no registry to publish ``device.{online,offline}``.
+
+    Lifecycle ``@on`` handlers must be delivered through the
+    PresenceCollector's add/remove callbacks instead. Per-device event
+    subscriptions still go through the broker, regardless of mode.
+    """
+
+    async def _setup_d2d(self, driver):
+        """Wire driver to a fake router + a real-ish PresenceCollector stand-in."""
+        from device_connect_edge.discovery import PresenceCollector
+
+        class FakeMessaging:
+            async def subscribe(self, *a, **kw): return MagicMock()
+            async def subscribe_with_subject(self, *a, **kw): return MagicMock()
+
+        class FakeDevice:
+            def __init__(self, collector):
+                self._d2d_collector = collector
+
+        class FakeRouter:
+            def __init__(self, messaging):
+                self._messaging = messaging
+                self._tenant = "beta"
+
+        messaging = FakeMessaging()
+        collector = PresenceCollector(messaging, tenant="beta", device_id="self")
+        driver._router = FakeRouter(messaging)
+        driver._device = FakeDevice(collector)
+        await driver.setup_subscriptions()
+        return collector
+
+    @pytest.mark.asyncio
+    async def test_peer_lost_routes_through_collector(self):
+        """In D2D mode, @on(event_name='peer_lost') registers an
+        on_peer_removed listener instead of subscribing to a subject."""
+        seen = []
+
+        class MyDriver(DeviceDriver):
+            device_type = "test"
+
+            @on(event_name="peer_lost")
+            async def on_lost(self, device_id, event_name, payload):
+                seen.append((device_id, event_name, payload))
+
+            async def connect(self): pass
+            async def disconnect(self): pass
+
+        driver = MyDriver()
+        collector = await self._setup_d2d(driver)
+
+        # Listener is registered on the collector, NOT a broker
+        # subscription.
+        assert len(collector._peer_removed_listeners) == 1
+
+        # Trigger the listener directly.
+        await collector._emit_peer_removed("interlock-01")
+        assert seen == [("interlock-01", "device.offline", {})]
+
+    @pytest.mark.asyncio
+    async def test_peer_present_routes_through_collector(self):
+        seen = []
+
+        class MyDriver(DeviceDriver):
+            device_type = "test"
+
+            @on(event_name="peer_present")
+            async def on_present(self, device_id, event_name, payload):
+                seen.append((device_id, event_name, payload))
+
+            async def connect(self): pass
+            async def disconnect(self): pass
+
+        driver = MyDriver()
+        collector = await self._setup_d2d(driver)
+
+        assert len(collector._new_peer_listeners) == 1
+
+        await collector._emit_new_peer("camera-7")
+        assert seen == [("camera-7", "device.online", {})]
+
+    @pytest.mark.asyncio
+    async def test_d2d_lifecycle_device_id_filter_exact(self):
+        """device_id= filter applies in the D2D delivery path too."""
+        seen = []
+
+        class MyDriver(DeviceDriver):
+            device_type = "test"
+
+            @on(device_id="interlock-01", event_name="peer_lost")
+            async def on_lost(self, device_id, event_name, payload):
+                seen.append(device_id)
+
+            async def connect(self): pass
+            async def disconnect(self): pass
+
+        driver = MyDriver()
+        collector = await self._setup_d2d(driver)
+
+        # Unrelated device -- handler should not fire.
+        await collector._emit_peer_removed("camera-99")
+        assert seen == []
+
+        # Target device -- handler fires.
+        await collector._emit_peer_removed("interlock-01")
+        assert seen == ["interlock-01"]
+
+    @pytest.mark.asyncio
+    async def test_d2d_lifecycle_device_id_filter_glob(self):
+        """Glob device_id= filter applies in the D2D delivery path."""
+        seen = []
+
+        class MyDriver(DeviceDriver):
+            device_type = "test"
+
+            @on(device_id="interlock-*", event_name="peer_lost")
+            async def on_lost(self, device_id, event_name, payload):
+                seen.append(device_id)
+
+            async def connect(self): pass
+            async def disconnect(self): pass
+
+        driver = MyDriver()
+        collector = await self._setup_d2d(driver)
+
+        for did in ("interlock-01", "interlock-99", "laser-01"):
+            await collector._emit_peer_removed(did)
+        assert seen == ["interlock-01", "interlock-99"]
+
+    @pytest.mark.asyncio
+    async def test_d2d_per_device_event_still_uses_broker(self):
+        """Per-device events go through the broker even in D2D mode."""
+        from device_connect_edge.discovery import PresenceCollector
+
+        class MyDriver(DeviceDriver):
+            device_type = "test"
+
+            @on(device_id="cam-001", event_name="motion_detected")
+            async def on_motion(self, device_id, event_name, payload):
+                pass
+
+            async def connect(self): pass
+            async def disconnect(self): pass
+
+        captured = {}
+
+        async def fake_subscribe(subject, callback, **kwargs):
+            captured["subject"] = subject
+            return MagicMock()
+
+        messaging = AsyncMock()
+        messaging.subscribe_with_subject = AsyncMock(side_effect=fake_subscribe)
+
+        class FakeDevice:
+            def __init__(self, collector):
+                self._d2d_collector = collector
+
+        class FakeRouter:
+            def __init__(self):
+                self._messaging = messaging
+                self._tenant = "beta"
+
+        collector = PresenceCollector(messaging, tenant="beta", device_id="self")
+        driver = MyDriver()
+        driver._router = FakeRouter()
+        driver._device = FakeDevice(collector)
+        await driver.setup_subscriptions()
+
+        # Per-device event still goes through the broker subscription;
+        # nothing is wired into the collector lifecycle listeners.
+        assert captured["subject"] == "device-connect.beta.cam-001.event.motion_detected"
+        assert collector._new_peer_listeners == []
+        assert collector._peer_removed_listeners == []
+
+
+class TestPresenceCollectorRemovedCallback:
+    """Symmetric callback for peer removals (graceful + timeout)."""
+
+    @pytest.mark.asyncio
+    async def test_graceful_departure_fires_on_peer_removed(self):
+        import json
+        from device_connect_edge.discovery import PresenceCollector
+
+        seen = []
+
+        async def on_removed(device_id):
+            seen.append(device_id)
+
+        messaging = AsyncMock()
+        collector = PresenceCollector(
+            messaging, tenant="beta", device_id="self",
+            on_peer_removed=on_removed,
+        )
+
+        # Seed: peer is currently known.
+        collector._peers["interlock-01"] = {"_last_seen": 0}
+
+        # Inject a graceful departure message.
+        msg = json.dumps({
+            "device_id": "interlock-01",
+            "departing": True,
+        }).encode()
+        await collector._on_presence(msg)
+
+        assert seen == ["interlock-01"]
+        assert "interlock-01" not in collector._peers
+
+    @pytest.mark.asyncio
+    async def test_prune_timeout_fires_on_peer_removed(self):
+        """Stale peers pruned by _prune_loop fire on_peer_removed."""
+        import time
+        from device_connect_edge.discovery import PresenceCollector
+
+        seen = []
+
+        async def on_removed(device_id):
+            seen.append(device_id)
+
+        messaging = AsyncMock()
+        collector = PresenceCollector(
+            messaging, tenant="beta", device_id="self",
+            on_peer_removed=on_removed,
+        )
+
+        # Seed: a peer whose _last_seen is way in the past.
+        collector._peers["camera-99"] = {"_last_seen": time.time() - 10_000}
+
+        # Walk the prune body directly (avoid waiting on the sleep loop).
+        async with collector._lock:
+            stale = [
+                did for did, info in collector._peers.items()
+                if time.time() - info.get("_last_seen", 0) > 1
+            ]
+            for did in stale:
+                del collector._peers[did]
+        for did in stale:
+            await collector._emit_peer_removed(did)
+
+        assert seen == ["camera-99"]
+
+    @pytest.mark.asyncio
+    async def test_add_on_peer_removed_supports_multiple_listeners(self):
+        """Multiple @on handlers can register without clobbering each other."""
+        from device_connect_edge.discovery import PresenceCollector
+
+        seen_a, seen_b = [], []
+
+        async def cb_a(d): seen_a.append(d)
+        async def cb_b(d): seen_b.append(d)
+
+        collector = PresenceCollector(AsyncMock(), tenant="beta", device_id="self")
+        collector.add_on_peer_removed(cb_a)
+        collector.add_on_peer_removed(cb_b)
+
+        await collector._emit_peer_removed("rig-7")
+        assert seen_a == ["rig-7"]
+        assert seen_b == ["rig-7"]
+
+    @pytest.mark.asyncio
+    async def test_constructor_callback_coexists_with_listeners(self):
+        """Single-listener constructor pattern keeps working."""
+        from device_connect_edge.discovery import PresenceCollector
+
+        seen_ctor, seen_added = [], []
+
+        async def ctor_cb(d): seen_ctor.append(d)
+        async def added_cb(d): seen_added.append(d)
+
+        collector = PresenceCollector(
+            AsyncMock(), tenant="beta", device_id="self",
+            on_new_peer=ctor_cb,
+        )
+        collector.add_on_new_peer(added_cb)
+
+        await collector._emit_new_peer("peer-1")
+        assert seen_ctor == ["peer-1"]
+        assert seen_added == ["peer-1"]


### PR DESCRIPTION
## Summary

- Deliver `@on(event_name="peer_present"|"peer_lost")` handlers via `PresenceCollector` callbacks when a D2D collector is present, so D2D drivers see the same lifecycle events as registry-mode drivers (which already get them through #27's broker subject).
- `PresenceCollector` gains symmetric `on_peer_removed` support and a multi-listener model (back-compat with the existing `collector._on_new_peer = ...` pattern in `device.py`).
- 9 new tests; existing `@on` and registry-mode behavior unchanged.

## Background

This is the rebased content of PR #31, which was merged into the now-orphaned stacked base branch `feat/peer-lifecycle-events` after #27 squash-merged to `main` first. The diff against `main` is the same 390 LOC as before.

## How

`discovery.py`:
- `PresenceCollector` grows symmetric `on_peer_removed` support (fires on `departing: true` graceful departure AND on prune-timeout in `_prune_loop`).
- Multi-listener model: constructor-form `on_new_peer` / `on_peer_removed` kwargs still work as single-listener seeds; new `add_on_new_peer` / `add_on_peer_removed` methods append additional listeners. The existing `collector._on_new_peer = ...` pattern in `device.py` keeps working via a back-compat property.

`drivers/base.py`:
- `_setup_subscription` checks `self._device._d2d_collector` for lifecycle aliases; if present, the handler is wired via the collector's new listener methods (`_setup_lifecycle_d2d`) instead of subscribing to the broker subject.
- Per-device events are unaffected; still subscribe through the broker.

Glob and exact `device_id=` filters apply post-hoc inside the delivery wrapper (same `_device_id_matches` helper as #27).

## Tests

9 new tests:

```
TestLifecycleSubscriptionsD2D
  test_peer_lost_routes_through_collector
  test_peer_present_routes_through_collector
  test_d2d_lifecycle_device_id_filter_exact
  test_d2d_lifecycle_device_id_filter_glob
  test_d2d_per_device_event_still_uses_broker

TestPresenceCollectorRemovedCallback
  test_graceful_departure_fires_on_peer_removed
  test_prune_timeout_fires_on_peer_removed
  test_add_on_peer_removed_supports_multiple_listeners
  test_constructor_callback_coexists_with_listeners
```

## Test plan

- [ ] Edge unit tests pass
- [ ] Integration suite passes (note: #32 fixes a separate pre-existing zenoh discovery flake that surfaced on the #27 merge)