### PR TITLE
feat(portal): mark UI as testing-only, not for production

### DIFF
--- a/packages/device-connect-server/device_connect_server/portal/templates/auth/cli_approve.html
+++ b/packages/device-connect-server/device_connect_server/portal/templates/auth/cli_approve.html
@@ -8,6 +8,10 @@
 </head>
 <body class="h-full flex items-center justify-center">
   <div class="w-full max-w-lg">
+    <div class="mb-6 rounded-lg p-3 bg-amber-50 border border-amber-300 text-amber-900 text-sm text-center">
+      <p class="font-semibold">Testing version only</p>
+      <p class="text-xs mt-1">This is not a production version. Do not use with real or sensitive data.</p>
+    </div>
     <div class="text-center mb-8">
       <div class="inline-flex items-center justify-center w-12 h-12 bg-indigo-600 rounded-xl mb-4">
         <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/packages/device-connect-server/device_connect_server/portal/templates/base.html
+++ b/packages/device-connect-server/device_connect_server/portal/templates/base.html
@@ -21,6 +21,7 @@
               </svg>
             </div>
             <span class="font-semibold text-gray-900">Device Connect</span>
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-amber-100 text-amber-800 border border-amber-300" title="This is a testing version, not a production version. Do not use with real or sensitive data.">TESTING ONLY — NOT FOR PRODUCTION</span>
           </a>
           {% if user.role == 'admin' %}
           <a href="/admin" class="text-sm {% if nav == 'admin' %}text-indigo-600 font-medium{% else %}text-gray-500 hover:text-gray-700{% endif %}">Dashboard</a>

--- a/packages/device-connect-server/device_connect_server/portal/templates/login.html
+++ b/packages/device-connect-server/device_connect_server/portal/templates/login.html
@@ -9,6 +9,10 @@
 </head>
 <body class="h-full flex items-center justify-center">
   <div class="w-full max-w-sm">
+    <div class="mb-6 rounded-lg p-3 bg-amber-50 border border-amber-300 text-amber-900 text-sm text-center">
+      <p class="font-semibold">Testing version only</p>
+      <p class="text-xs mt-1">This is not a production version. Do not use with real or sensitive data.</p>
+    </div>
     <div class="text-center mb-8">
       <div class="inline-flex items-center justify-center w-12 h-12 bg-indigo-600 rounded-xl mb-4">
         <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/packages/device-connect-server/device_connect_server/portal/templates/signup.html
+++ b/packages/device-connect-server/device_connect_server/portal/templates/signup.html
@@ -9,6 +9,10 @@
 </head>
 <body class="h-full flex items-center justify-center">
   <div class="w-full max-w-sm">
+    <div class="mb-6 rounded-lg p-3 bg-amber-50 border border-amber-300 text-amber-900 text-sm text-center">
+      <p class="font-semibold">Testing version only</p>
+      <p class="text-xs mt-1">This is not a production version. Do not use with real or sensitive data.</p>
+    </div>
     <div class="text-center mb-8">
       <div class="inline-flex items-center justify-center w-12 h-12 bg-indigo-600 rounded-xl mb-4">
         <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- Adds an amber "Testing version only" banner above the logo on `login.html`, `signup.html`, and `auth/cli_approve.html`.
- Adds a "TESTING ONLY — NOT FOR PRODUCTION" pill next to the "Device Connect" logo in `base.html`, so the warning shows on every authenticated page (dashboard, devices, coding agents, admin).

Stacked on top of #38 — base is `feat/registry-pagination`. Merge #38 first; this PR will retarget to `main` automatically.

## Test plan
- [ ] Visit `/login` — verify the amber banner renders above the indigo logo card.
- [ ] Visit `/signup` — verify the banner renders.
- [ ] Hit the CLI approve flow (`/auth/cli/...`) — verify the banner renders.
- [ ] Sign in and visit `/dashboard`, `/devices`, `/coding-agents`, and the admin pages — verify the amber "TESTING ONLY — NOT FOR PRODUCTION" pill renders next to the Device Connect logo in the top nav on each page.