### PR TITLE
fix(registry): evict stale lease on heartbeat so re-registration can fire

### DIFF
--- a/packages/device-connect-server/device_connect_server/registry/service/registry.py
+++ b/packages/device-connect-server/device_connect_server/registry/service/registry.py
@@ -148,8 +148,24 @@ class DeviceRegistry:
         lk = self._lease_key(tenant, device_id)
         lease = self.leases.get(lk)
         if lease:
-            lease.refresh()
-            return
+            # Lease can die in etcd (TTL-expired) while we still hold the stale
+            # handle. etcd3gw's refresh() returns the new TTL, or -1 when the
+            # lease has already expired -- it does NOT raise in that case. A
+            # transport/server error does raise. Either way, drop the stale
+            # handle and fall through to recovery so has_lease() reports False
+            # and the server can ask the device to re-register.
+            try:
+                new_ttl = lease.refresh()
+            except Exception:
+                new_ttl = -1
+            if new_ttl >= 0:
+                return
+            self.leases.pop(lk, None)
+            _logger.info(
+                "stale lease for %s/%s dropped; attempting recovery",
+                tenant,
+                device_id,
+            )
 
         # No lease handle — attempt recovery
         if ttl is None:

--- a/packages/device-connect-server/tests/device_connect_server/test_registry_service.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_registry_service.py
@@ -531,12 +531,15 @@ class TestRefreshHeartbeat:
         mock_etcd3gw.client.return_value = mock_client
 
         mock_lease = MagicMock()
+        mock_lease.refresh.return_value = 30  # etcd returns the new TTL
         reg = DeviceRegistry(host="localhost", port=2379)
         reg.leases["default/camera-001"] = mock_lease
 
         reg.refresh("default", "camera-001")
 
         mock_lease.refresh.assert_called_once()
+        # Live lease stays tracked
+        assert reg.leases["default/camera-001"] is mock_lease
 
     @patch("device_connect_server.registry.service.registry.etcd3gw")
     def test_refresh_noop_for_unknown_device(self, mock_etcd3gw):
@@ -553,7 +556,9 @@ class TestRefreshHeartbeat:
         mock_etcd3gw.client.return_value = mock_client
 
         lease_a = MagicMock()
+        lease_a.refresh.return_value = 30
         lease_b = MagicMock()
+        lease_b.refresh.return_value = 30
         reg = DeviceRegistry(host="localhost", port=2379)
         reg.leases["tenant-a/cam-001"] = lease_a
         reg.leases["tenant-b/cam-001"] = lease_b
@@ -635,6 +640,67 @@ class TestRefreshLeaseRecovery:
             expected_key, json.dumps(existing), lease=new_lease,
         )
         # The lease should now be tracked
+        assert reg.leases["default/cam-001"] is new_lease
+
+    @patch("device_connect_server.registry.service.registry.etcd3gw")
+    def test_refresh_evicts_expired_lease_no_raise(self, mock_etcd3gw):
+        """A stale handle whose lease TTL-expired (refresh() -> -1, no raise)
+        is evicted, so has_lease() reports False and the data is gone."""
+        mock_client = _make_mock_etcd_client()
+        # etcd dropped the lease and its attached key when the TTL expired.
+        mock_client.get.return_value = []
+        mock_etcd3gw.client.return_value = mock_client
+
+        stale_lease = MagicMock()
+        stale_lease.refresh.return_value = -1  # etcd: lease already expired
+        reg = DeviceRegistry(host="localhost", port=2379)
+        reg.leases["default/cam-001"] = stale_lease
+
+        reg.refresh("default", "cam-001", ttl=15)
+
+        stale_lease.refresh.assert_called_once()
+        # Stale handle dropped -> server will fire requestRegistration.
+        assert "default/cam-001" not in reg.leases
+        assert reg.has_lease("default", "cam-001") is False
+        # No phantom lease re-created when etcd has no data.
+        mock_client.lease.assert_not_called()
+
+    @patch("device_connect_server.registry.service.registry.etcd3gw")
+    def test_refresh_evicts_stale_lease_on_error(self, mock_etcd3gw):
+        """A transport/server error from refresh() also evicts the handle."""
+        mock_client = _make_mock_etcd_client()
+        mock_client.get.return_value = []
+        mock_etcd3gw.client.return_value = mock_client
+
+        stale_lease = MagicMock()
+        stale_lease.refresh.side_effect = RuntimeError("lease not found")
+        reg = DeviceRegistry(host="localhost", port=2379)
+        reg.leases["default/cam-001"] = stale_lease
+
+        reg.refresh("default", "cam-001", ttl=15)
+
+        assert "default/cam-001" not in reg.leases
+        assert reg.has_lease("default", "cam-001") is False
+
+    @patch("device_connect_server.registry.service.registry.etcd3gw")
+    def test_refresh_recovers_when_data_survives_lease(self, mock_etcd3gw):
+        """If the stale lease died but the device doc is still in etcd,
+        refresh() re-issues a lease and re-stores the data."""
+        mock_client = _make_mock_etcd_client()
+        existing = {"device_id": "cam-001", "status": {"online": True}}
+        mock_client.get.return_value = [json.dumps(existing)]
+        new_lease = MagicMock()
+        mock_client.lease.return_value = new_lease
+        mock_etcd3gw.client.return_value = mock_client
+
+        stale_lease = MagicMock()
+        stale_lease.refresh.return_value = -1
+        reg = DeviceRegistry(host="localhost", port=2379)
+        reg.leases["default/cam-001"] = stale_lease
+
+        reg.refresh("default", "cam-001", ttl=15)
+
+        mock_client.lease.assert_called_once_with(ttl=15)
         assert reg.leases["default/cam-001"] is new_lease
 
 


### PR DESCRIPTION
## Summary

Fixes a server-side bug where a device that TTL-expired in etcd would stay missing from the registry until some unrelated event forced a fresh `register()`.

Stacked on **#41** (which is stacked on **#38**). This PR's own diff is just the registry fix below.

`DeviceRegistry.refresh()` returned early whenever the process-wide in-memory `leases` dict still held a handle for the device -- even after etcd had already TTL-expired that lease. The handle is never evicted on its own, so on a "stranded" heartbeat:

- etcd3gw's `Lease.refresh()` does **not** raise against an expired lease. Per the [etcd keepalive spec](https://etcd.io/docs/v3.5/dev-guide/apispec/swagger/rpc.swagger.json) the response omits the `TTL` field, and etcd3gw returns `-1` in that case (see `etcd3gw/lease.py`).
- So the stale handle survived, `has_lease()` kept reporting `True`, and the heartbeat path in `registry/service/main.py` never sent `requestRegistration`.
- The device stayed absent from the registry until an unrelated fresh `register()` call (e.g. the edge's NATS-disconnect path) happened to fire.

## Fix

`refresh()` now inspects the **return value** of `lease.refresh()` (and still catches transport/server errors): on `TTL == -1` or an exception, it drops the stale handle and falls through to the existing recovery code.

```python
if lease:
    try:
        new_ttl = lease.refresh()
    except Exception:
        new_ttl = -1
    if new_ttl >= 0:
        return
    self.leases.pop(lk, None)   # stale -> drop, fall through to recovery
```

After eviction `has_lease()` correctly reports `False`, the server asks the device to re-register, and the edge replies with its registration payload (the `requestRegistration` wire path already exists on both sides). Recovery completes on the next heartbeat -- **no client-side change required.**

The architectural choice ("registry asks the device to re-register on a stranded heartbeat") was already made; it was just gated behind a stale-state check that lied.

## Test plan

- [x] `test_refresh_evicts_expired_lease_no_raise` -- `refresh() -> -1`, no raise: handle evicted, `has_lease()` False, no phantom lease created when etcd has no data
- [x] `test_refresh_evicts_stale_lease_on_error` -- `refresh()` raises: handle still evicted
- [x] `test_refresh_recovers_when_data_survives_lease` -- stale lease but doc still in etcd: re-issues lease + re-stores data
- [x] Existing `TestRefreshHeartbeat` tests updated to return a realistic int TTL from the mocked lease (a bare `MagicMock` return would not survive the new `>= 0` comparison)
- [x] Full registry suite: 48 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)