### PR TITLE
security_infra: lock WS to same-origin by default; fix tenant-config regen

### DIFF
--- a/packages/device-connect-server/security_infra/README.md
+++ b/packages/device-connect-server/security_infra/README.md
@@ -327,6 +327,8 @@ DC_NATS_WS_PORT=8443 \
 
 `setup_deployment.sh` prints the exact one-liner (with the value you passed) at the end of its run so you can copy-paste it.
 
+**Origin checking.** When `--websocket-allowed-origins` is omitted, the generated block emits `same_origin: true`, so the listener only accepts WebSocket handshakes whose `Origin` header matches the request host. (nats-server's `same_origin` defaults to `false` — accepting any Origin — so this is emitted explicitly rather than relying on the default.) Pass `--websocket-allowed-origins` only when a reverse proxy rewrites the Host header and you need to allow specific cross-origin pages.
+
 The override binds the port to `127.0.0.1:8443` by default. **Plain WS on the listener is intentional**: the assumption is that a reverse proxy (Caddy, nginx, Cloudflare Tunnel, ...) terminates TLS and proxies to loopback. Without TLS in front, NATS JWTs travel in cleartext.
 
 To skip the reverse proxy and have NATS do TLS termination natively, pass `--websocket-tls-cert` and `--websocket-tls-key` to `setup_deployment.sh`. The resulting block uses `tls { ... }` instead of `no_tls: true`, and you can safely expose the port directly (override `DC_NATS_WS_BIND=0.0.0.0:8443` in the env when running compose).

--- a/packages/device-connect-server/security_infra/manage_tenants.sh
+++ b/packages/device-connect-server/security_infra/manage_tenants.sh
@@ -71,7 +71,12 @@ regenerate_nats_config() {
   if [ -f "${output}" ] && grep -q '^# Device Connect additions' "${output}"; then
     additions=$(sed -n '/^# Device Connect additions/,$p' "${output}")
   fi
-  nsc generate config --mem-resolver --config-file "${output}" 2>/dev/null
+  # Newer nsc (v2.12+) refuses to overwrite an existing --config-file, and the
+  # file always exists here (we just read it for "${additions}"). Remove it
+  # first, matching setup_deployment.sh, or generation fails before the
+  # preserved additions can be appended back.
+  rm -f "${output}"
+  nsc generate config --mem-resolver --config-file "${output}"
   if [ -n "${additions}" ]; then
     printf '\n%s\n' "${additions}" >> "${output}"
   else

--- a/packages/device-connect-server/security_infra/manage_tenants.sh
+++ b/packages/device-connect-server/security_infra/manage_tenants.sh
@@ -60,13 +60,28 @@ usage() {
 
 regenerate_nats_config() {
   local output="${SCRIPT_DIR}/nats-jwt-generated.conf"
+  # Preserve any previously-appended server directives (listen, http_port,
+  # max_payload, the websocket {} block, native tls {}, ...) across this
+  # regeneration. `nsc generate config` rewrites the file from scratch, so
+  # without this it silently drops everything below the marker -- which has
+  # taken the browser WebSocket listener (added via setup_deployment.sh
+  # --enable-websocket) offline in production every time a tenant or device
+  # was added. All appended directives live below the marker line.
+  local additions=""
+  if [ -f "${output}" ] && grep -q '^# Device Connect additions' "${output}"; then
+    additions=$(sed -n '/^# Device Connect additions/,$p' "${output}")
+  fi
   nsc generate config --mem-resolver --config-file "${output}" 2>/dev/null
-  cat >> "${output}" <<EOF
+  if [ -n "${additions}" ]; then
+    printf '\n%s\n' "${additions}" >> "${output}"
+  else
+    cat >> "${output}" <<EOF
 
 # Device Connect additions
 listen: 0.0.0.0:4222
 http_port: 8222
 EOF
+  fi
   echo "    NATS config regenerated: ${output}"
 }
 

--- a/packages/device-connect-server/security_infra/setup_deployment.sh
+++ b/packages/device-connect-server/security_infra/setup_deployment.sh
@@ -50,8 +50,8 @@ Browser-based devices (WebSocket):
   --websocket-port PORT           WS listen port inside the container (default: 8443).
   --websocket-allowed-origins LIST
                                   Comma-separated list of allowed Origin headers.
-                                  Defaults to empty, which keeps nats-server's
-                                  same_origin=true behavior. Set this only when
+                                  Defaults to empty, which emits same_origin=true
+                                  (same-origin only). Set this only when
                                   a reverse proxy rewrites Host headers (e.g.
                                   the page is at https://app.example.com and
                                   the WS endpoint is wss://app.example.com/nats
@@ -199,23 +199,26 @@ if [ "$ENABLE_WEBSOCKET" -eq 1 ]; then
       echo "  # port is exposed to the network."
       echo "  no_tls: true"
     fi
-    if [ -n "$WS_ALLOWED_ORIGINS" ]; then
-      # Trim each token and skip empties so "a.com,,b.com" or a trailing
-      # comma doesn't produce a stray "" entry in allowed_origins.
-      origins_json=$(echo "$WS_ALLOWED_ORIGINS" | awk -F, '{
-        out=""; first=1;
-        for (i=1; i<=NF; i++) {
-          tok = $i;
-          gsub(/^[ \t]+|[ \t]+$/, "", tok);
-          if (tok == "") continue;
-          out = out (first ? "" : ", ") "\"" tok "\"";
-          first = 0;
-        }
-        print out
-      }')
-      if [ -n "$origins_json" ]; then
-        echo "  allowed_origins: [${origins_json}]"
-      fi
+    # Trim each token and skip empties so "a.com,,b.com" or a trailing
+    # comma doesn't produce a stray "" entry in allowed_origins.
+    origins_json=$(echo "$WS_ALLOWED_ORIGINS" | awk -F, '{
+      out=""; first=1;
+      for (i=1; i<=NF; i++) {
+        tok = $i;
+        gsub(/^[ \t]+|[ \t]+$/, "", tok);
+        if (tok == "") continue;
+        out = out (first ? "" : ", ") "\"" tok "\"";
+        first = 0;
+      }
+      print out
+    }')
+    if [ -n "$origins_json" ]; then
+      echo "  allowed_origins: [${origins_json}]"
+    else
+      # No explicit origins: lock to same-origin. nats-server's same_origin
+      # defaults to FALSE, so an empty/omitted allowed_origins would otherwise
+      # accept connections from ANY Origin. Emit it explicitly to be safe.
+      echo "  same_origin: true"
     fi
     echo "  compression: true"
     echo "}"


### PR DESCRIPTION
Supersedes #41 (whose branch was stacked on `feat/registry-pagination`; that base has since squash-merged into `main` via #38, leaving #41's GitHub object stuck on a stale pre-rebase head that refused to merge). Same verified commits, rebased onto `main`.

## Summary

Two `security_infra` fixes from @soupat's review on #41:

- **`setup_deployment.sh` — same-origin default.** The WebSocket block now always parses `--websocket-allowed-origins` and branches: it emits `allowed_origins: [...]` only when the operator passes a non-empty list, otherwise it emits `same_origin: true`. nats-server's `same_origin` defaults to `false`, so the previous empty/omitted `allowed_origins` left the listener open to **any** Origin — the opposite of the documented "same-origin by default". Fixed the `--help` text and README to match.
- **`manage_tenants.sh` — regen overwrite.** `regenerate_nats_config()` now `rm -f`s the config before `nsc generate config` (matching `setup_deployment.sh`), because newer `nsc` (v2.12+) refuses to overwrite an existing `--config-file` and the file always exists here (just read for the preserved additions). Dropped the `2>/dev/null` that was masking the failure.

## Test plan

- [x] `bash -n` clean on both scripts
- [x] origins emission verified: empty/whitespace → `same_origin: true`; explicit values → clean `allowed_origins` list
- [x] clean fast-forward into `main` (verified via local test-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)