### PR TITLE
portal: route invoke/event-stream by registry-canonical device id

### DIFF
--- a/packages/device-connect-server/device_connect_server/portal/templates/coding_agents/AGENTS.md.j2
+++ b/packages/device-connect-server/device_connect_server/portal/templates/coding_agents/AGENTS.md.j2
@@ -151,22 +151,21 @@ HTTP equivalents live in [Appendix A](#appendix-a-http-api-reference).
 ## 3. Provision a device
 
 Provisioning creates a NATS credential bound to this tenant and registers the
-device id with the portal. Device ids are tenant-prefixed: a request for
-`cam-001` lands as `{{ tenant }}-cam-001`.
+device id with the portal. By default, `dc-portalctl devices provision cam-001`
+mints credentials for `{{ tenant }}-cam-001` and adds that id to the registry.
 
-> ⚠️ **Self-registered devices break the prefix assumption.** The portal
-> **always** rewrites `<id>` → `{{ tenant }}-<id>` on the invoke path unless
-> `<id>` already starts with `{{ tenant }}-`. Devices created via
-> `dc-portalctl devices provision` follow this convention. Devices that
-> self-register from a browser / firmware / external SDK can use any id
-> they want — `dc-portalctl devices list` returns whatever they chose,
-> verbatim. When the registered id does not start with `{{ tenant }}-`,
-> the rewrite produces a NATS subject no one is subscribed to, and every
-> `dc-portalctl devices invoke` (and the equivalent HTTP endpoint) returns
-> `code -1` with `elapsed_ms ≈ 0` — instantly, not after a timeout. Detect
-> by scanning `devices list`: any id that does not start with `{{ tenant }}-`
-> is unreachable via the portal HTTP path until the server fix lands (see
-> §7 and the troubleshooting table).
+> 🛑 **Never invent a device id.** Always `dc-portalctl devices list` (or call
+> `discover()`) before invoking. Two id shapes coexist on the bus:
+> CLI-provisioned ids that start with `{{ tenant }}-` (e.g. `{{ tenant }}-cam-001`),
+> and self-registered ids from browser / firmware / shared-credential SDK
+> clients that can be anything the device chose (e.g. `audience.r2.s1.k2uus2n3`).
+> The portal addresses each device by exactly the id it registered with —
+> short-name aliases like `cam-001` still resolve to a provisioned
+> `{{ tenant }}-cam-001` automatically, but the source of truth is the
+> registry, not any naming convention. If you guess and your guess isn't in
+> `devices list`, you'll get an instant `code -1` "not responding" with
+> `elapsed_ms ≈ 0` — that's the symptom of an unregistered id, not an
+> offline device.
 
 ```bash
 dc-portalctl devices provision cam-001 \
@@ -498,16 +497,16 @@ field carries a JSON-RPC error dict
 `{"error": {"code": int, "message": str}}`. Codes from the NATS backend:
 
 - `-1` "Device {id} is not responding" — no responders on the published
-  subject. The invoke path doesn't do a registry existence check, so bad
-  ids surface here, not as 404. **Use `elapsed_ms` to disambiguate:**
+  subject. The invoke path resolves the id against the registry before
+  publishing, so a typo against a registered id is no longer routed to a
+  ghost subject. **Use `elapsed_ms` to disambiguate:**
   - `elapsed_ms ≈ 0` → no responder at all. Cross-check `devices list`:
-    - `Last Seen` fresh (<1 min) → **ID-rewrite mismatch.** The device is
-      online but subscribed under an id that doesn't match the portal's
-      rewrite (`<id>` → `{{ tenant }}-<id>`). Common with self-registered
-      browser / firmware devices — see §3 callout. No HTTP-only workaround
-      today; use `device-connect-agent-tools` from Python or report to
-      the operator.
+    - `Last Seen` fresh (<1 min) → the device is online but its RPC
+      handler isn't subscribed (registered but not running, or crashed
+      mid-task). Read its driver process logs.
     - `Last Seen` stale → device is actually offline.
+    - id absent from `devices list` → typo'd or guessed id; nothing was
+      registered under that name. Always `devices list` first.
   - `elapsed_ms ≈ timeout` → subject had a subscriber that never replied;
     device crashed mid-RPC or its handler hung.
 - `-2` "Request timed out after {timeout}s" — target busy / unresponsive
@@ -638,7 +637,7 @@ Exit codes: `0` ok, `2` no events / arg error, `4` 401, `5` 403, `6` 404,
 | Device retries `nkeys library required for JWT auth` forever | `nkeys` import is failing — almost always because its `pynacl` transitive can't load (prebuilt wheel incompatible with the host libc) | Reinstall `device-connect-edge` (`nkeys` is already a required dep — `pip install --upgrade --force-reinstall device-connect-edge`); on glibc < 2.34 rebuild `pynacl` from source per Section 5. `pip install nkeys` only helps if deps were originally installed with `--no-deps` |
 | Device process crashes at startup with `AttributeError: '...' object has no attribute '_routines_collected'` (or `_internal_handlers_collected`) | Custom `__init__` skipped `super().__init__()` | Call `super().__init__()` first (Section 4) |
 | `invoke_remote` raises `PublishError` / `RequestTimeoutError` | Target offline, wrong tenant-prefixed id, or unresponsive. Backend-dependent: NATS → `PublishError` for "no responders", `RequestTimeoutError` for actual timeouts; Zenoh → typically `RequestTimeoutError` after retries | `dc-portalctl devices list` to confirm id; check target's logs |
-| `dc-portalctl devices invoke` succeeds (HTTP 200) but `response.error.code = -1` with `elapsed_ms ≈ 0`, and `devices list` shows the target online with a fresh `Last Seen` | **ID-rewrite mismatch.** Portal rewrote `<id>` → `{{ tenant }}-<id>` but the device subscribed on the raw id (self-registered, no `provision` step — typical of browser / firmware clients). The rewritten subject has no responder. | No HTTP-only workaround today. Either (a) use `device-connect-agent-tools` from Python — it publishes to the raw NATS subject from `discover()` and bypasses the rewrite — or (b) report to the operator so they can upgrade the portal (see §3 callout and the server-fix note in §7). |
+| `dc-portalctl devices invoke` succeeds (HTTP 200) but `response.error.code = -1` with `elapsed_ms ≈ 0`, and `devices list` shows the target online with a fresh `Last Seen` | Registered device but its RPC handler isn't subscribed — driver process is up enough to register / heartbeat but not servicing functions. (The portal now routes by the registry-canonical id, so this is no longer the ID-rewrite case.) | Read the driver process logs; restart the driver |
 | `dc-portalctl devices invoke` succeeds (HTTP 200) but `response.error.code = -1 / -2` (other shapes) | Device-level failure: -1 = "Device not responding" (no responders), -2 = "Request timed out". Target offline / unresponsive | Verify target with `dc-portalctl devices list`; inspect target logs |
 | `dc-portalctl devices invoke` returns HTTP 502 `invoke_failed` | Infrastructure-level failure — broker unreachable, registry creds missing/wrong, or backend connect failed (`device_connect_server.portal.services.nats_rpc.connect()` raises before the try/except in `invoke()`) | Check portal logs for the underlying exception; verify NATS broker reachable and `registry.creds.json` is present and valid |
 | `revoke-credentials` or `delete` returns HTTP 501 `not_implemented` | Backend hasn't wired `rotate_device_credentials` / `remove_device` (none do as of 0.2.3) | See Section 3 lifecycle limitations callout; stop the device process directly and/or edit the backing store |

--- a/packages/device-connect-server/device_connect_server/portal/views/agent_api.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/agent_api.py
@@ -137,11 +137,64 @@ def _resolve_tenant(request: web.Request) -> tuple[str, web.Response | None]:
 
 
 def _full_device_name(tenant: str, device_id: str) -> str:
-    """Match the existing devices.create_device convention: tenant-prefixed, unless
-    the caller already passed a fully-qualified id."""
+    """Synthesize the default device name a `provision` call would have minted.
+
+    Used ONLY for provisioning (the device doesn't exist yet, so the
+    registry can't tell us the canonical id). For every other endpoint
+    that addresses an *existing* device on the bus, use
+    `_resolve_device_id` so self-registered devices (browser / firmware
+    / shared-credential SDK) — whose ids land in the registry without
+    the tenant prefix — are addressed by their registered id, not by a
+    synthetic prefixed twin that no subscriber listens on.
+    """
     if device_id.startswith(f"{tenant}-"):
         return device_id
     return f"{tenant}-{device_id}"
+
+
+def _resolve_device_id(tenant: str, raw_id: str) -> str:
+    """Resolve a caller-supplied device id to its canonical registry form.
+
+    The portal's invoke / event-stream / credentials / revoke / delete
+    endpoints all publish on `device-connect.{tenant}.{device_id}.cmd`
+    (or `.event.{name}`). The subscriber on that subject is the running
+    device process — and the subject it listens on is determined by the
+    id under which the device *registered itself*, not by any naming
+    convention the portal assumes.
+
+    Self-registered devices (BrowserPhone, firmware, anything using
+    `DeviceRuntime` with a shared-credential SDK) commonly register with
+    an id that does NOT start with `{tenant}-`. The old code unconditionally
+    rewrote `<id>` → `{tenant}-<id>`, sent the RPC to a subject with no
+    responder, and surfaced an instant "Device is not responding" while
+    `devices list` showed the device online — a debugging dead-end.
+
+    Lookup order:
+      1. The id exactly as the caller passed it (catches self-registered
+         devices AND callers who already typed the full provisioned form).
+      2. The provision-style prefix `{tenant}-<id>` (preserves the legacy
+         short-name alias for devices provisioned via `dc-portalctl`).
+
+    On a hit, the registry's canonical `device_id` field wins — that is
+    what the device subscribes on.
+
+    Falls back to `_full_device_name(tenant, raw_id)` when the registry
+    is unreachable or the id is genuinely unknown, so a caller invoking a
+    just-provisioned-but-not-yet-online device still gets today's
+    "no responders" path rather than a hard 404.
+    """
+    try:
+        doc = registry_client.get_device(tenant, raw_id)
+        if not doc and not raw_id.startswith(f"{tenant}-"):
+            doc = registry_client.get_device(tenant, _full_device_name(tenant, raw_id))
+        if doc:
+            canonical = doc.get("device_id")
+            if canonical:
+                return canonical
+    except Exception:
+        logger.debug("resolve_device_id: registry lookup failed for %s/%s",
+                     tenant, raw_id, exc_info=True)
+    return _full_device_name(tenant, raw_id)
 
 
 def _audit(request: web.Request, action: str, **fields):
@@ -509,7 +562,7 @@ async def device_credentials_get(request: web.Request) -> web.Response:
         return err
 
     device_id = request.match_info["device_id"]
-    full_name = _full_device_name(tenant, device_id)
+    full_name = _resolve_device_id(tenant, device_id)
     filename = f"{full_name}.creds.json"
     cred = credentials_svc.get_credential_data(filename)
 
@@ -556,7 +609,7 @@ async def device_credentials_rotate(request: web.Request) -> web.Response:
         return err
 
     device_id = request.match_info["device_id"]
-    full_name = _full_device_name(tenant, device_id)
+    full_name = _resolve_device_id(tenant, device_id)
 
     backend = get_backend()
     rotate = getattr(backend, "rotate_device_credentials", None)
@@ -597,7 +650,7 @@ async def device_revoke(request: web.Request) -> web.Response:
         return err
 
     device_id = request.match_info["device_id"]
-    full_name = _full_device_name(tenant, device_id)
+    full_name = _resolve_device_id(tenant, device_id)
     filename = f"{full_name}.creds.json"
 
     # Same shape as the portal handler: a backend without remove_device
@@ -676,7 +729,7 @@ async def device_delete(request: web.Request) -> web.Response:
         return err
 
     device_id = request.match_info["device_id"]
-    full_name = _full_device_name(tenant, device_id)
+    full_name = _resolve_device_id(tenant, device_id)
 
     backend = get_backend()
     remove = getattr(backend, "remove_device", None)
@@ -717,7 +770,7 @@ async def device_invoke(request: web.Request) -> web.Response:
         return err
 
     device_id = request.match_info["device_id"]
-    full_name = _full_device_name(tenant, device_id)
+    full_name = _resolve_device_id(tenant, device_id)
 
     try:
         body = await request.json()
@@ -790,7 +843,7 @@ async def invoke_with_fallback(request: web.Request) -> web.Response:
     backend = get_backend()
     failures = []
     for idx, raw_id in enumerate(ids):
-        full_name = _full_device_name(tenant, raw_id)
+        full_name = _resolve_device_id(tenant, raw_id)
         started = time.monotonic()
         try:
             response = await backend.rpc_invoke(tenant, full_name, function, params, timeout=timeout)
@@ -801,7 +854,7 @@ async def invoke_with_fallback(request: web.Request) -> web.Response:
             return _ok(
                 {"device_id": full_name, "function": function,
                  "elapsed_ms": elapsed_ms, "response": response,
-                 "tried": [{"device_id": _full_device_name(tenant, x), "ok": (i == idx)}
+                 "tried": [{"device_id": _resolve_device_id(tenant, x), "ok": (i == idx)}
                            for i, x in enumerate(ids[: idx + 1])],
                  "failures": failures},
                 trace_id=trace,
@@ -846,7 +899,7 @@ async def device_event_stream(request: web.Request) -> web.Response:
         validate_name(event_name, "event")
     except ValueError as e:
         return _err(status=400, code="invalid_event_name", message=str(e))
-    full_name = _full_device_name(tenant, device_id)
+    full_name = _resolve_device_id(tenant, device_id)
 
     fmt = (request.query.get("format") or "ndjson").lower()
     if fmt not in ("ndjson", "sse"):

--- a/packages/device-connect-server/tests/device_connect_server/test_portal_agent_api.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portal_agent_api.py
@@ -691,3 +691,111 @@ class TestInvokeFallbackDuplicates:
             tried = body["result"]["tried"]
             assert [t["ok"] for t in tried] == [False, False, True]
             assert len(tried) == 3
+
+
+# ── invoke addresses devices by their registry-canonical id ───────
+
+
+class TestInvokeUsesCanonicalRegistryId:
+    """invoke / fallback / event-stream must route to the device id that is
+    actually registered on the bus, not to a synthetic tenant-prefixed twin.
+
+    The pre-fix code unconditionally rewrote `<id>` → `<tenant>-<id>`. For
+    devices provisioned via `dc-portalctl devices provision` this matched
+    what the device subscribed on. For devices that self-register from a
+    browser / firmware / shared-credential SDK — common in the
+    flashlight-auditorium BrowserPhone shape — the rewrite published to a
+    NATS subject no one was listening on, and the call returned HTTP 200
+    with `code: -1, elapsed_ms ~0, message: "Device <full> is not responding"`.
+    That looked indistinguishable from "device offline" and burned an entire
+    debugging session in the wild before being root-caused.
+    """
+
+    async def test_self_registered_id_passes_through_unchanged(self, invoke_client):
+        """Browser-style id `audience.r2.s1.k2uus2n3` must hit the bus
+        exactly as registered, with no tenant prefix bolted on."""
+        seen: dict = {}
+
+        class _FakeBackend:
+            def backend_name(self): return "test"
+
+            async def rpc_invoke(self, tenant, full_name, fn, params, timeout):
+                seen["full_name"] = full_name
+                return {"ok": True}
+
+        registry_doc = {"device_id": "audience.r2.s1.k2uus2n3"}
+        with patch(
+            "device_connect_server.portal.views.agent_api.registry_client.get_device",
+            return_value=registry_doc,
+        ), patch(
+            "device_connect_server.portal.views.agent_api.get_backend",
+            return_value=_FakeBackend(),
+        ):
+            r = await invoke_client.post(
+                "/api/agent/v1/devices/audience.r2.s1.k2uus2n3/invoke",
+                headers=H(),
+                json={"function": "set_screen_color", "params": {"r": 255, "g": 0, "b": 0}},
+            )
+            assert r.status == 200
+        # Pre-fix: this would have been "acme-audience.r2.s1.k2uus2n3" (no responder).
+        assert seen["full_name"] == "audience.r2.s1.k2uus2n3"
+
+    async def test_short_name_aliases_to_provisioned_full_id(self, invoke_client):
+        """Caller types the provisioning short name; resolver finds the
+        provisioned `acme-cam-001` in the registry on the second probe and
+        routes there. Legacy CLI workflows keep working."""
+        seen: dict = {}
+
+        def _get_device(tenant, did):
+            return {"device_id": "acme-cam-001"} if did == "acme-cam-001" else None
+
+        class _FakeBackend:
+            def backend_name(self): return "test"
+
+            async def rpc_invoke(self, tenant, full_name, fn, params, timeout):
+                seen["full_name"] = full_name
+                return {"ok": True}
+
+        with patch(
+            "device_connect_server.portal.views.agent_api.registry_client.get_device",
+            side_effect=_get_device,
+        ), patch(
+            "device_connect_server.portal.views.agent_api.get_backend",
+            return_value=_FakeBackend(),
+        ):
+            r = await invoke_client.post(
+                "/api/agent/v1/devices/cam-001/invoke",
+                headers=H(),
+                json={"function": "ping"},
+            )
+            assert r.status == 200
+        assert seen["full_name"] == "acme-cam-001"
+
+    async def test_unknown_id_falls_back_to_provision_style_prefix(self, invoke_client):
+        """Registry miss preserves the legacy behavior: publish to
+        `<tenant>-<id>` so a just-provisioned-but-not-yet-registered device
+        still works, and a truly absent device surfaces as "not responding"
+        the same way it does today."""
+        seen: dict = {}
+
+        class _FakeBackend:
+            def backend_name(self): return "test"
+
+            async def rpc_invoke(self, tenant, full_name, fn, params, timeout):
+                seen["full_name"] = full_name
+                return {"error": {"code": -1, "message": "no responder"}}
+
+        with patch(
+            "device_connect_server.portal.views.agent_api.registry_client.get_device",
+            return_value=None,
+        ), patch(
+            "device_connect_server.portal.views.agent_api.get_backend",
+            return_value=_FakeBackend(),
+        ):
+            r = await invoke_client.post(
+                "/api/agent/v1/devices/cam-001/invoke",
+                headers=H(),
+                json={"function": "ping"},
+            )
+            assert r.status == 200
+        assert seen["full_name"] == "acme-cam-001"


### PR DESCRIPTION
## Summary

Replace the unconditional `<id>` → `<tenant>-<id>` rewrite on the portal's action endpoints with a registry lookup that returns the device id under which the target actually subscribed on the bus.

The pre-existing rewrite matched `dc-portalctl devices provision <name>` and worked for CLI-provisioned devices, but it broke devices that self-register from a browser, firmware, or shared-credential SDK — those land in the registry verbatim, and the rewritten NATS subject (`device-connect.<tenant>.<tenant>-<raw>.cmd`) had no responder. The portal returned HTTP 200 with `code -1, elapsed_ms ~0, "Device <full> is not responding"`, indistinguishable from "device offline" without source-diving. This was previously called out in the AGENTS playbook (commit 93881be) as a doc-only workaround; this PR is the underlying server fix.

## What changes

- **`agent_api.py`** — new `_resolve_device_id(tenant, raw_id)` helper. Tries the id as-given, then `<tenant>-<id>`. On a hit, returns the registry doc's canonical `device_id`. On miss / etcd error, falls back to `_full_device_name` so callers invoking a just-provisioned-not-yet-registered device still see today's "no responders" path rather than a hard 404. Used in every endpoint that addresses an existing device on the bus: `device_invoke`, `invoke_with_fallback` (per-iteration + `tried` array), `device_credentials_get`, `device_credentials_rotate`, `device_revoke`, `device_delete`, `device_event_stream`. `device_provision` keeps `_full_device_name` since the device doesn't exist in the registry yet at that point.

- **`test_portal_agent_api.py`** — new `TestInvokeUsesCanonicalRegistryId` covering: self-registered id passes through unchanged, short-name aliases to the provisioned `<tenant>-<short>`, and registry-miss falls back to the provision-style prefix.

- **`AGENTS.md.j2`** — replace the "Device ids are tenant-prefixed" rule with "never invent a device id; always discover first" and explain that two id shapes coexist (provisioned vs self-registered). Drop the §7 "ID-rewrite mismatch / no HTTP-only workaround" guidance since the HTTP path now works for both shapes; re-aim the `elapsed_ms≈0` troubleshooting entry at the registered-but-handler-not-subscribed case.

After this change, agents no longer need to learn two id conventions — the registry is the single source of truth and the portal addresses devices by exactly the id under which they registered.

## Test plan

- [ ] `pytest packages/device-connect-server/tests/device_connect_server/test_portal_agent_api.py -v` (CI matrix Python 3.12; not run locally because this Mac only has 3.14 + missing aiohttp wheels)
- [ ] Manual: from a host with `device-connect-agent-tools` configured against the `alpha` tenant on `portal.deviceconnect.dev`, hit a BrowserPhone (e.g. `audience.r2.s1.kndyobvt`) via both `dc-portalctl devices invoke <id> set_screen_color …` and the equivalent HTTP `POST /api/agent/v1/devices/<id>/invoke`. Pre-fix both return `code -1, elapsed_ms ~0`. Post-fix both succeed in 50-200 ms.
- [ ] Manual: provision `cam-001`, invoke it as `cam-001` (short name) — must still resolve to `<tenant>-cam-001` on the bus (no regression on the legacy CLI flow).
- [ ] Manual: invoke a fully unknown id — must still surface "no responders" (preserves today's behaviour for not-yet-registered devices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)