### PR TITLE
fix(portal): wire ADMIN_PASS through env_file; treat empty pass as unset

### DIFF
--- a/packages/device-connect-server/device_connect_server/portal/config.py
+++ b/packages/device-connect-server/device_connect_server/portal/config.py
@@ -37,9 +37,14 @@ ETCD_HOST = os.environ.get("ETCD_HOST", "localhost")
 ETCD_PORT = int(os.environ.get("ETCD_PORT", "2379"))
 
 # Admin credentials
+# Treat an empty ADMIN_PASS the same as unset: generate a password AND flag it
+# as generated so it gets logged. Keying ADMIN_PASS_GENERATED off membership in
+# os.environ alone would silently generate a password (because "" is falsy) but
+# never log it, locking the operator out.
 ADMIN_USER = os.environ.get("ADMIN_USER", "admin")
-ADMIN_PASS = os.environ.get("ADMIN_PASS") or secrets.token_urlsafe(16)
-ADMIN_PASS_GENERATED = "ADMIN_PASS" not in os.environ
+_admin_pass = os.environ.get("ADMIN_PASS") or None
+ADMIN_PASS = _admin_pass or secrets.token_urlsafe(16)
+ADMIN_PASS_GENERATED = _admin_pass is None
 
 # Paths
 SECURITY_INFRA_DIR = Path(os.environ.get(

--- a/packages/device-connect-server/infra/.env.multitenant.example
+++ b/packages/device-connect-server/infra/.env.multitenant.example
@@ -2,3 +2,9 @@
 #
 # List of tenants (comma-separated, must match tenants created with manage_tenants.sh)
 DC_TENANTS=alpha,beta,gamma,delta,epsilon
+
+# Admin login for the portal. The portal reads these from this file (wired in
+# via the portal service's env_file). If ADMIN_PASS is left unset/empty, the
+# portal generates a random password on startup and prints it to the logs.
+ADMIN_USER=admin
+# ADMIN_PASS=change-me

--- a/packages/device-connect-server/infra/.env.multitenant.example
+++ b/packages/device-connect-server/infra/.env.multitenant.example
@@ -3,9 +3,10 @@
 # List of tenants (comma-separated, must match tenants created with manage_tenants.sh)
 DC_TENANTS=alpha,beta,gamma,delta,epsilon
 
-# Admin login for the portal. Both values are injected into the portal
-# container via the portal service's env_file (which points at this file).
-# ADMIN_USER defaults to "admin" if omitted. If ADMIN_PASS is left unset/empty,
-# the portal generates a random password on startup and prints it to the logs.
+# Admin login for the portal. Once this file is copied to infra/.env (see the
+# header above), both values are injected into the portal container via the
+# portal service's env_file. ADMIN_USER defaults to "admin" if omitted. If
+# ADMIN_PASS is left unset/empty, the portal generates a random password on
+# startup and prints it to the logs.
 ADMIN_USER=admin
 # ADMIN_PASS=change-me

--- a/packages/device-connect-server/infra/.env.multitenant.example
+++ b/packages/device-connect-server/infra/.env.multitenant.example
@@ -3,8 +3,9 @@
 # List of tenants (comma-separated, must match tenants created with manage_tenants.sh)
 DC_TENANTS=alpha,beta,gamma,delta,epsilon
 
-# Admin login for the portal. The portal reads these from this file (wired in
-# via the portal service's env_file). If ADMIN_PASS is left unset/empty, the
-# portal generates a random password on startup and prints it to the logs.
+# Admin login for the portal. Both values are injected into the portal
+# container via the portal service's env_file (which points at this file).
+# ADMIN_USER defaults to "admin" if omitted. If ADMIN_PASS is left unset/empty,
+# the portal generates a random password on startup and prints it to the logs.
 ADMIN_USER=admin
 # ADMIN_PASS=change-me

--- a/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
+++ b/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
@@ -110,13 +110,14 @@ services:
       NATS_CONTAINER: dc-nats
       ETCD_HOST: etcd
       ETCD_PORT: "2379"
-      ADMIN_USER: ${ADMIN_USER:-admin}
-      # ADMIN_PASS is injected from infra/.env via env_file below (NOT the
-      # compose-level .env, which is interpolation-only and never reaches the
-      # container). If unset there, the portal auto-generates one and logs it.
+      # Admin creds (ADMIN_USER, ADMIN_PASS) come from infra/.env via env_file
+      # below -- deliberately NOT listed here, since an environment: entry would
+      # override env_file. The compose-level .env is interpolation-only and
+      # never reaches the container. If ADMIN_PASS is unset the portal
+      # auto-generates one and logs it; ADMIN_USER defaults to "admin".
       SECURITY_INFRA_DIR: /app/security_infra
       CREDS_DIR: /root/.device-connect/credentials
-    # Inject infra/.env into the container so ADMIN_PASS (and any other deploy
+    # Inject infra/.env into the container so admin creds (and any other deploy
     # secrets) reach the portal. Optional: omit the file to use inline env vars
     # and let the portal auto-generate the admin password.
     env_file:

--- a/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
+++ b/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
@@ -118,8 +118,11 @@ services:
       SECURITY_INFRA_DIR: /app/security_infra
       CREDS_DIR: /root/.device-connect/credentials
     # Inject infra/.env into the container so admin creds (and any other deploy
-    # secrets) reach the portal. Optional: omit the file to use inline env vars
-    # and let the portal auto-generate the admin password.
+    # secrets) reach the portal. This is the ONLY path that delivers ADMIN_USER/
+    # ADMIN_PASS to the container -- host env vars (e.g. ADMIN_PASS=... docker
+    # compose up) are not forwarded. Optional (required: false): if infra/.env
+    # is absent, ADMIN_USER falls back to "admin" and the portal auto-generates
+    # and logs the admin password.
     env_file:
       - path: .env
         required: false

--- a/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
+++ b/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
@@ -111,9 +111,17 @@ services:
       ETCD_HOST: etcd
       ETCD_PORT: "2379"
       ADMIN_USER: ${ADMIN_USER:-admin}
-      # ADMIN_PASS: set via env var or .env file; auto-generated if omitted
+      # ADMIN_PASS is injected from infra/.env via env_file below (NOT the
+      # compose-level .env, which is interpolation-only and never reaches the
+      # container). If unset there, the portal auto-generates one and logs it.
       SECURITY_INFRA_DIR: /app/security_infra
       CREDS_DIR: /root/.device-connect/credentials
+    # Inject infra/.env into the container so ADMIN_PASS (and any other deploy
+    # secrets) reach the portal. Optional: omit the file to use inline env vars
+    # and let the portal auto-generate the admin password.
+    env_file:
+      - path: .env
+        required: false
     volumes:
       - ~/.device-connect/credentials:/root/.device-connect/credentials
       - ../security_infra:/app/security_infra

--- a/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
+++ b/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
@@ -124,7 +124,7 @@ services:
     # is absent, ADMIN_USER falls back to "admin" and the portal auto-generates
     # and logs the admin password.
     env_file:
-      - path: .env
+      - path: .env  # NOTE: requires a Docker Compose version that supports env_file objects + `required`; otherwise create infra/.env
         required: false
     volumes:
       - ~/.device-connect/credentials:/root/.device-connect/credentials

--- a/packages/device-connect-server/tests/device_connect_server/test_portal_config_admin_pass.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portal_config_admin_pass.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for portal admin-password resolution.
+
+``portal.config`` resolves ``ADMIN_PASS`` at import time and exposes
+``ADMIN_PASS_GENERATED`` so the startup path knows whether to log the
+generated password. The trap these tests pin: an *empty* ``ADMIN_PASS``
+must be treated exactly like an unset one -- generate a random password
+AND flag it as generated so it gets logged. The earlier implementation
+keyed ``ADMIN_PASS_GENERATED`` off ``"ADMIN_PASS" not in os.environ``,
+so ``ADMIN_PASS=""`` silently generated a password but never logged it,
+locking the operator out.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _reload_config(monkeypatch, value):
+    """Reload portal.config with ADMIN_PASS set to ``value`` (None = unset)."""
+    if value is None:
+        monkeypatch.delenv("ADMIN_PASS", raising=False)
+    else:
+        monkeypatch.setenv("ADMIN_PASS", value)
+    from device_connect_server.portal import config
+
+    return importlib.reload(config)
+
+
+def test_unset_admin_pass_is_generated(monkeypatch):
+    config = _reload_config(monkeypatch, None)
+    assert config.ADMIN_PASS_GENERATED is True
+    assert config.ADMIN_PASS  # a password was generated
+
+
+def test_empty_admin_pass_is_generated(monkeypatch):
+    config = _reload_config(monkeypatch, "")
+    # Empty string must behave like unset: generated AND flagged so it logs.
+    assert config.ADMIN_PASS_GENERATED is True
+    assert config.ADMIN_PASS
+
+
+def test_explicit_admin_pass_is_not_generated(monkeypatch):
+    config = _reload_config(monkeypatch, "s3cret-pass")
+    assert config.ADMIN_PASS_GENERATED is False
+    assert config.ADMIN_PASS == "s3cret-pass"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _restore_config():
+    """Reload config from the ambient environment once the module finishes so
+    the import-time ADMIN_PASS state doesn't leak into other test modules. This
+    is module-scoped so it runs after every per-test ``monkeypatch`` has already
+    restored ``os.environ``."""
+    yield
+    from device_connect_server.portal import config
+
+    importlib.reload(config)


### PR DESCRIPTION
## Problem

The multitenant compose file (`infra/docker-compose-multitenant-nats.yml`) documents `ADMIN_PASS` as settable "via env var or `.env` file", but the `portal` service has **no `env_file`** and no inline `ADMIN_PASS` reference. Compose's project-level `.env` is **interpolation-only** and never reaches the container, so a deployer's `infra/.env` `ADMIN_PASS` is silently ignored — the portal mints a **fresh random admin password on every rebuild**, breaking the existing admin login.

In practice operators work around this with an untracked local edit (`ADMIN_PASS: ${ADMIN_PASS}`) that is easily lost on `git pull`/`checkout` during an upgrade.

There's a second, nastier trap in the config logic:

```python
ADMIN_PASS = os.environ.get("ADMIN_PASS") or secrets.token_urlsafe(16)
ADMIN_PASS_GENERATED = "ADMIN_PASS" not in os.environ
```

If `ADMIN_PASS=""` (set but empty), the value path generates a random password (because `""` is falsy), but `ADMIN_PASS_GENERATED` is `False` — so it **generates a password and never logs it**, locking the operator out with no recovery.

## Fix

1. **compose** — add an optional `env_file` (`infra/.env`) to the `portal` service so `ADMIN_PASS` and other deploy secrets actually reach the container. `required: false` keeps the inline-env-var usage (`DC_TENANTS=... docker compose up`) working when no `.env` exists.
2. **config.py** — treat an empty `ADMIN_PASS` the same as unset: generate **and** log. Closes the silent-lockout path regardless of how the env is provided.
3. **docs** — document `ADMIN_USER`/`ADMIN_PASS` in `.env.multitenant.example`.

## Notes

- `env_file` paths in this compose file resolve relative to the compose file's dir (`infra/`), matching the existing `build.context: ../../..` convention, so `path: .env` → `infra/.env`.
- `environment:` still wins over `env_file` for keys it sets (e.g. `ADMIN_USER`), so no precedence surprises.
- No version bump included.