### PR TITLE
release: bump to 0.2.5

### DIFF
--- a/packages/device-connect-agent-tools/pyproject.toml
+++ b/packages/device-connect-agent-tools/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "device-connect-agent-tools"
-version = "0.2.4"
+version = "0.2.5"
 description = "Framework-agnostic tools for Device Connect — discover and invoke IoT devices over NATS/Zenoh"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/device-connect-edge/pyproject.toml
+++ b/packages/device-connect-edge/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "device-connect-edge"
-version = "0.2.4"
+version = "0.2.5"
 description = "Device Connect Edge — lightweight edge device runtime with Zenoh/NATS messaging and D2D communication"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/device-connect-server/pyproject.toml
+++ b/packages/device-connect-server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "device-connect-server"
-version = "0.2.4"
+version = "0.2.5"
 description = "Device Connect — edge device runtime with Zenoh/NATS messaging, D2D communication, and IoT orchestration"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps all three packages from **0.2.4 → 0.2.5** in lockstep (`device-connect-edge`, `device-connect-server`, `device-connect-agent-tools`).

This cuts a release for the 5 commits merged to `main` since the `v0.2.4` tag (the version was never bumped after v0.2.4):

| PR | Type | Summary |
|----|------|---------|
| #54 | feat | expose authenticated RPC caller to `@rpc` handlers |
| #52 | feat | Zenoh multi-tenant portal — bring-up, tenant isolation, hardening |
| #49 | docs | fix agent playbook http→https 405 on auth login |
| #47 | fix  | wire `ADMIN_PASS` through env_file; treat empty pass as unset |
| #39 | test | scalable fleet integration coverage |

### Release procedure (per `.github/workflows/release.yml`)
1. ✅ Bump `version` in each `packages/*/pyproject.toml` (this PR).
2. After merge: tag `v0.2.5` on `main` and push it.
3. Approve the `pypi` environment deployment in the Actions UI — Trusted Publishing (OIDC) then publishes all three packages to PyPI.

Diff is the three `version =` lines only; inter-package deps use `>=` floors and need no change.