### PR TITLE
docs: note macOS multicast fallback for D2D discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,27 @@ The device starts in D2D mode automatically — no URLs needed. Any other Device
 
 > **Note:** `DEVICE_CONNECT_ALLOW_INSECURE=true` skips TLS and is intended for local development only.
 
+<details>
+<summary>Not seeing the device? (macOS / multicast)</summary>
+
+D2D mode discovers peers over Zenoh UDP multicast. On some setups — notably
+macOS over loopback — multicast scouting doesn't connect two local processes, so
+`discover(...)` comes back empty and `invoke(...)` reports no responders. Give
+the peers an explicit TCP link instead: have the device listen, and point the
+agent at it.
+
+```bash
+# device — listen on a local endpoint
+DEVICE_CONNECT_ALLOW_INSECURE=true DEVICE_CONNECT_DISCOVERY_MODE=d2d \
+  ZENOH_LISTEN=tcp/localhost:7447 python sensor.py
+
+# agent — connect to that endpoint
+DEVICE_CONNECT_ALLOW_INSECURE=true DEVICE_CONNECT_DISCOVERY_MODE=d2d \
+  ZENOH_CONNECT=tcp/localhost:7447 python your_agent.py
+```
+
+</details>
+
 ### 4. Discover and invoke from an agent
 
 ```bash


### PR DESCRIPTION
The quick-start says a device started in D2D mode is discovered "instantly, no URLs needed." That relies on Zenoh UDP multicast scouting, which on macOS (loopback) does not reliably connect two local processes — `discover(...)` returns empty and `invoke(...)` reports no responders.

This adds a **collapsed** `<details>` note in step 3 documenting the explicit TCP-link fallback (`ZENOH_LISTEN` on the device, `ZENOH_CONNECT` on the agent), so the happy path stays uncluttered while users who hit the issue have an answer.

Verified locally on macOS: with the TCP link the agent discovers the device and `invoke` returns the reading.