### PR TITLE
feat(types): allow extra fields on DeviceStatus

### DIFF
--- a/packages/device-connect-edge/device_connect_edge/types.py
+++ b/packages/device-connect-edge/device_connect_edge/types.py
@@ -244,6 +244,13 @@ class DeviceStatus(BaseModel):
     Contains information about the device's current operational state,
     which is updated via heartbeats and status changes.
 
+    Arbitrary fields are allowed beyond the standard ones (same policy as
+    DeviceIdentity), enabling deployment-specific runtime state without a
+    core schema change. The registry already merges heartbeat payloads as
+    raw dicts, so extra keys reach ``status`` in the device record either
+    way; allowing them here keeps the typed path (DeviceDriver.status(),
+    registration) from silently dropping what the untyped path carries.
+
     Example:
         DeviceStatus(
             ts=datetime.utcnow(),
@@ -252,9 +259,13 @@ class DeviceStatus(BaseModel):
             busy_score=0.7,
             battery=85,
             online=True,
-            error_state=None
+            error_state=None,
+            # Custom fields allowed:
+            halo={"zone": "aisle-3", "count": 3},
         )
     """
+    model_config = {"extra": "allow"}
+
     ts: datetime = Field(
         default_factory=datetime.utcnow,
         description="Timestamp of last status update"

--- a/packages/device-connect-edge/tests/test_types.py
+++ b/packages/device-connect-edge/tests/test_types.py
@@ -5,6 +5,7 @@
 """Unit tests for device_connect_edge.types module."""
 
 import pytest
+from pydantic import ValidationError
 
 from device_connect_edge.types import (
     DeviceState,
@@ -57,6 +58,31 @@ class TestDeviceStatus:
         status = DeviceStatus()
         # Should have sensible defaults
         assert status is not None
+
+    def test_extra_fields_allowed(self):
+        # Deployment-specific runtime state survives the typed path, matching
+        # the registry's raw-dict heartbeat merge (and DeviceIdentity policy).
+        status = DeviceStatus(
+            location="aisle-3",
+            halo={"zone": "aisle-3", "count": 3},
+            fleet_group="picking",
+        )
+        assert status.halo == {"zone": "aisle-3", "count": 3}
+        assert status.fleet_group == "picking"
+
+    def test_extra_fields_roundtrip(self):
+        payload = {
+            "location": "aisle-3",
+            "halo": {"zone": "aisle-3", "members": [{"device_id": "fork-3"}]},
+        }
+        dumped = DeviceStatus(**payload).model_dump(mode="json")
+        assert dumped["halo"] == payload["halo"]
+        assert DeviceStatus(**dumped).halo == payload["halo"]
+
+    def test_known_field_validation_still_applies(self):
+        # extra=allow must not weaken validation of declared fields.
+        with pytest.raises(ValidationError):
+            DeviceStatus(busy_score=1.5)
 
 
 class TestFunctionDef:


### PR DESCRIPTION
## What

One line: `model_config = {"extra": "allow"}` on `DeviceStatus`, matching the policy `DeviceIdentity` already has.

## Why

`DeviceStatus` declared no `extra` policy, so pydantic's default silently dropped unknown keys. That makes the two halves of a device record behave differently: identity accepts device-specific metadata, status does not.

It also puts the typed and untyped paths out of step. `DeviceRegistry.update_status()` merges heartbeat payloads into the record as raw dicts with no schema validation, so deployment-specific runtime state written over the heartbeat subject already lands in `status` and is readable by agents. The only place it vanished was the typed path: a driver returning it from `DeviceDriver.status()`, or an explicit `DeviceStatus` passed at registration, where `status.model_dump(exclude_none=True)` (device.py) never saw the field. No error, no log line, just a missing key.

The motivating case is an authoritative network-side location provider writing an egocentric awareness object ("halo": the tracked entities around a node) onto device records. This PR carries none of that vocabulary into core, and takes no position on the naming or on selector-side exposure. It only makes the extension supported instead of accidental.

## Scope

- No new fields, no behaviour change for any existing device.
- Declared-field validation is unchanged: `busy_score=1.5` still raises, covered by a new test.
- Nested dicts and lists roundtrip through `model_dump(mode="json")` and back.

## Tests

Three tests added to `TestDeviceStatus` in `packages/device-connect-edge/tests/test_types.py`: extras accepted and readable, extras surviving a dump/reload roundtrip, and a guard that declared-field validation still applies.

- edge suite: 568 passed
- agent-tools suite: 269 passed. The 12 errors in `test_integration.py` are Zenoh broker connection failures at fixture setup (`tcp/localhost:7447`, needs the Docker compose stack); they reproduce identically on unmodified `main` in the same environment.