### PR TITLE
fix(ci): pin ruff and declare the lint rule set explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: '3.12'
+  RUFF_VERSION: '0.16.1'
 
 jobs:
   # ── Unit tests (parallel, no Docker) ──────────────────────────
@@ -82,7 +83,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install ruff
-        run: pip install ruff
+        # Pinned: an unpinned linter makes CI a moving target, and a new ruff
+        # release can turn a green tree red without a commit. Bump deliberately.
+        run: pip install ruff==${{ env.RUFF_VERSION }}
       - name: Lint all packages
         run: |
           ruff check packages/device-connect-edge/

--- a/packages/device-connect-edge/device_connect_edge/types.py
+++ b/packages/device-connect-edge/device_connect_edge/types.py
@@ -244,6 +244,13 @@ class DeviceStatus(BaseModel):
     Contains information about the device's current operational state,
     which is updated via heartbeats and status changes.
 
+    Arbitrary fields are allowed beyond the standard ones (same policy as
+    DeviceIdentity), enabling deployment-specific runtime state without a
+    core schema change. The registry already merges heartbeat payloads as
+    raw dicts, so extra keys reach ``status`` in the device record either
+    way; allowing them here keeps the typed path (DeviceDriver.status(),
+    registration) from silently dropping what the untyped path carries.
+
     Example:
         DeviceStatus(
             ts=datetime.utcnow(),
@@ -252,9 +259,13 @@ class DeviceStatus(BaseModel):
             busy_score=0.7,
             battery=85,
             online=True,
-            error_state=None
+            error_state=None,
+            # Custom fields allowed:
+            halo={"zone": "aisle-3", "count": 3},
         )
     """
+    model_config = {"extra": "allow"}
+
     ts: datetime = Field(
         default_factory=datetime.utcnow,
         description="Timestamp of last status update"

--- a/packages/device-connect-edge/tests/test_types.py
+++ b/packages/device-connect-edge/tests/test_types.py
@@ -5,6 +5,7 @@
 """Unit tests for device_connect_edge.types module."""
 
 import pytest
+from pydantic import ValidationError
 
 from device_connect_edge.types import (
     DeviceState,
@@ -57,6 +58,31 @@ class TestDeviceStatus:
         status = DeviceStatus()
         # Should have sensible defaults
         assert status is not None
+
+    def test_extra_fields_allowed(self):
+        # Deployment-specific runtime state survives the typed path, matching
+        # the registry's raw-dict heartbeat merge (and DeviceIdentity policy).
+        status = DeviceStatus(
+            location="aisle-3",
+            halo={"zone": "aisle-3", "count": 3},
+            fleet_group="picking",
+        )
+        assert status.halo == {"zone": "aisle-3", "count": 3}
+        assert status.fleet_group == "picking"
+
+    def test_extra_fields_roundtrip(self):
+        payload = {
+            "location": "aisle-3",
+            "halo": {"zone": "aisle-3", "members": [{"device_id": "fork-3"}]},
+        }
+        dumped = DeviceStatus(**payload).model_dump(mode="json")
+        assert dumped["halo"] == payload["halo"]
+        assert DeviceStatus(**dumped).halo == payload["halo"]
+
+    def test_known_field_validation_still_applies(self):
+        # extra=allow must not weaken validation of declared fields.
+        with pytest.raises(ValidationError):
+            DeviceStatus(busy_score=1.5)
 
 
 class TestFunctionDef:

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,3 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 line-length = 120
+
+[lint]
+# State the rule set explicitly instead of inheriting ruff's built-in default.
+# The default is not a stable contract: ruff 0.16.0 widened it (adding UP, I,
+# BLE, PIE, TRY and more), which turned CI red on an unchanged tree because the
+# lint job installs ruff unpinned. These four are exactly what ruff selected by
+# default through 0.15.x, so this preserves the rule set the tree was written
+# against while making future ruff upgrades a no-op for lint.
+#
+# Adopting the wider set is a reasonable follow-up, but it is a ~700-finding
+# autofix sweep across every package and should land as its own change.
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
## Symptom

`lint` has failed on **every** CI run on `main` since 2026-07-24, including the nightly scheduled runs. It reports 704 findings on a tree nobody changed. Every PR inherits the red check.

## Cause

The lint job ran `pip install ruff`, unpinned. **ruff 0.16.0 was published 2026-07-23 at 19:10 UTC** and widened the built-in *default* rule set. The 2026-07-23 06:45 scheduled run got ruff 0.15.22 and was green; the 2026-07-24 06:45 run got 0.16.0 and was red. That is the entire delta, no source change involved.

The new findings are all style families this tree was never linted against:

| rule | count |
|---|---|
| UP045 non-pep604-annotation-optional | 207 |
| UP006 non-pep585-annotation | 196 |
| I001 unsorted-imports | 94 |
| UP035 deprecated-import | 51 |
| BLE001 blind-except | 48 |
| PIE790 unnecessary-placeholder | 39 |

The underlying fragility is that `ruff.toml` set only `line-length`, so the rule set was inherited from ruff's built-in default. That default is not a stable contract, which makes lint results a function of release timing rather than of the tree.

## Fix

1. **`ruff.toml`** declares the rule set explicitly: `select = ["E4", "E7", "E9", "F"]`, exactly what ruff selected by default through 0.15.x. This preserves the rules the tree was written against and makes future ruff upgrades a no-op for lint.
2. **`ci.yml`** pins the version through a `RUFF_VERSION` env var (`0.16.1`, current latest), so a linter bump becomes a reviewable commit rather than a surprise on a Friday.

Belt and braces on purpose: the pin makes today reproducible, the explicit `select` makes the next bump safe.

## Verification

Ran the lint job's four commands locally against three ruff versions straddling the break:

| ruff | result |
|---|---|
| 0.15.22 (last good) | All checks passed |
| 0.16.0 (the break) | All checks passed |
| 0.16.1 (pinned) | All checks passed |

Nothing previously caught is now suppressed. The 12 `F821` mentions in the failing log were pre-existing `# noqa: F821` comments quoted inside UP045 fix diffs, not new findings; `--select F821` is clean tree-wide.

## Follow-up, deliberately not here

Adopting the wider 0.16 rule set is worth doing. It is a ~700-finding autofix sweep touching every package, would conflict with anything in flight, and the UP006/UP045 annotation rewrites want their own review pass on the pydantic models. That belongs in its own PR, once `main` is green again.