### PR TITLE
Correct copyright start year: 2025, not 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2024-2026 Arm Limited
+   Copyright 2025-2026 Arm Limited
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/__init__.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/_normalize.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/_normalize.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/__init__.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/claude.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/claude.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/langchain.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/langchain.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/strands.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/strands.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/strands_agent.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/adapters/strands_agent.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/agent.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/agent.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/connection.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/connection.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/__init__.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/__main__.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/__main__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/bridge.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/bridge.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/config.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/device_connect_mcp.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/device_connect_mcp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/device_tools.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/device_tools.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/event_subscriptions.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/event_subscriptions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/router.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/router.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/schema.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/mcp/schema.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/device_connect_agent_tools/tools.py
+++ b/packages/device-connect-agent-tools/device_connect_agent_tools/tools.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/pyproject.toml
+++ b/packages/device-connect-agent-tools/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/__init__.py
+++ b/packages/device-connect-agent-tools/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/conftest.py
+++ b/packages/device-connect-agent-tools/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/fuzz/conftest.py
+++ b/packages/device-connect-agent-tools/tests/fuzz/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/fuzz/fuzz_jsonrpc_parsing.py
+++ b/packages/device-connect-agent-tools/tests/fuzz/fuzz_jsonrpc_parsing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/fuzz/fuzz_schema.py
+++ b/packages/device-connect-agent-tools/tests/fuzz/fuzz_schema.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/fuzz/test_fuzz_jsonrpc_parsing.py
+++ b/packages/device-connect-agent-tools/tests/fuzz/test_fuzz_jsonrpc_parsing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/fuzz/test_fuzz_schema.py
+++ b/packages/device-connect-agent-tools/tests/fuzz/test_fuzz_schema.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_broadcast.py
+++ b/packages/device-connect-agent-tools/tests/test_broadcast.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_claude_adapter.py
+++ b/packages/device-connect-agent-tools/tests/test_claude_adapter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_connection_unit.py
+++ b/packages/device-connect-agent-tools/tests/test_connection_unit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_device_connect_mcp_capabilities.py
+++ b/packages/device-connect-agent-tools/tests/test_device_connect_mcp_capabilities.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_discover.py
+++ b/packages/device-connect-agent-tools/tests/test_discover.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_integration.py
+++ b/packages/device-connect-agent-tools/tests/test_integration.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_invoke.py
+++ b/packages/device-connect-agent-tools/tests/test_invoke.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_langchain_adapter.py
+++ b/packages/device-connect-agent-tools/tests/test_langchain_adapter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_mcp_bridge_subscriptions.py
+++ b/packages/device-connect-agent-tools/tests/test_mcp_bridge_subscriptions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_normalize.py
+++ b/packages/device-connect-agent-tools/tests/test_normalize.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_strands_adapter.py
+++ b/packages/device-connect-agent-tools/tests/test_strands_adapter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_subscribe.py
+++ b/packages/device-connect-agent-tools/tests/test_subscribe.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-agent-tools/tests/test_tools_unit.py
+++ b/packages/device-connect-agent-tools/tests/test_tools_unit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/LICENSE
+++ b/packages/device-connect-edge/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024-2026 Arm Limited
+Copyright 2025-2026 Arm Limited
 PROPRIETARY AND CONFIDENTIAL
 All Rights Reserved.
 

--- a/packages/device-connect-edge/device_connect_edge/__init__.py
+++ b/packages/device-connect-edge/device_connect_edge/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/device.py
+++ b/packages/device-connect-edge/device_connect_edge/device.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/discovery.py
+++ b/packages/device-connect-edge/device_connect_edge/discovery.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/discovery_provider.py
+++ b/packages/device-connect-edge/device_connect_edge/discovery_provider.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/drivers/__init__.py
+++ b/packages/device-connect-edge/device_connect_edge/drivers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/drivers/base.py
+++ b/packages/device-connect-edge/device_connect_edge/drivers/base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/drivers/capability_loader.py
+++ b/packages/device-connect-edge/device_connect_edge/drivers/capability_loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/drivers/decorators.py
+++ b/packages/device-connect-edge/device_connect_edge/drivers/decorators.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/drivers/transport.py
+++ b/packages/device-connect-edge/device_connect_edge/drivers/transport.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/errors.py
+++ b/packages/device-connect-edge/device_connect_edge/errors.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/messaging/__init__.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/messaging/base.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/messaging/config.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/messaging/exceptions.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/messaging/mqtt_adapter.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/mqtt_adapter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/messaging/nats_adapter.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/nats_adapter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/messaging/zenoh_adapter.py
+++ b/packages/device-connect-edge/device_connect_edge/messaging/zenoh_adapter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/predicate.py
+++ b/packages/device-connect-edge/device_connect_edge/predicate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/registry_client.py
+++ b/packages/device-connect-edge/device_connect_edge/registry_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/selector.py
+++ b/packages/device-connect-edge/device_connect_edge/selector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/telemetry/__init__.py
+++ b/packages/device-connect-edge/device_connect_edge/telemetry/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/telemetry/config.py
+++ b/packages/device-connect-edge/device_connect_edge/telemetry/config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/telemetry/file_buffer_exporter.py
+++ b/packages/device-connect-edge/device_connect_edge/telemetry/file_buffer_exporter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/telemetry/metrics.py
+++ b/packages/device-connect-edge/device_connect_edge/telemetry/metrics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/telemetry/propagation.py
+++ b/packages/device-connect-edge/device_connect_edge/telemetry/propagation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/telemetry/tracer.py
+++ b/packages/device-connect-edge/device_connect_edge/telemetry/tracer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/device_connect_edge/types.py
+++ b/packages/device-connect-edge/device_connect_edge/types.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/examples/dht22_sensor/device_driver.py
+++ b/packages/device-connect-edge/examples/dht22_sensor/device_driver.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/examples/number_generator/device_simulator.py
+++ b/packages/device-connect-edge/examples/number_generator/device_simulator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/examples/string_generator/device_simulator.py
+++ b/packages/device-connect-edge/examples/string_generator/device_simulator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/pyproject.toml
+++ b/packages/device-connect-edge/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/__init__.py
+++ b/packages/device-connect-edge/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/fuzz/conftest.py
+++ b/packages/device-connect-edge/tests/fuzz/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/fuzz/fuzz_credentials_json.py
+++ b/packages/device-connect-edge/tests/fuzz/fuzz_credentials_json.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/fuzz/fuzz_jsonrpc_cmd.py
+++ b/packages/device-connect-edge/tests/fuzz/fuzz_jsonrpc_cmd.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/fuzz/fuzz_nats_creds.py
+++ b/packages/device-connect-edge/tests/fuzz/fuzz_nats_creds.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/fuzz/fuzz_pydantic_models.py
+++ b/packages/device-connect-edge/tests/fuzz/fuzz_pydantic_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/fuzz/report_hypothesis.py
+++ b/packages/device-connect-edge/tests/fuzz/report_hypothesis.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/fuzz/run_atheris.py
+++ b/packages/device-connect-edge/tests/fuzz/run_atheris.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/fuzz/test_fuzz_credentials_json.py
+++ b/packages/device-connect-edge/tests/fuzz/test_fuzz_credentials_json.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/fuzz/test_fuzz_jsonrpc_cmd.py
+++ b/packages/device-connect-edge/tests/fuzz/test_fuzz_jsonrpc_cmd.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/fuzz/test_fuzz_nats_creds.py
+++ b/packages/device-connect-edge/tests/fuzz/test_fuzz_nats_creds.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/fuzz/test_fuzz_pydantic_models.py
+++ b/packages/device-connect-edge/tests/fuzz/test_fuzz_pydantic_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_capability_loader.py
+++ b/packages/device-connect-edge/tests/test_capability_loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_device.py
+++ b/packages/device-connect-edge/tests/test_device.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_device_where.py
+++ b/packages/device-connect-edge/tests/test_device_where.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_discovery.py
+++ b/packages/device-connect-edge/tests/test_discovery.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_driver_transport.py
+++ b/packages/device-connect-edge/tests/test_driver_transport.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_drivers.py
+++ b/packages/device-connect-edge/tests/test_drivers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_errors.py
+++ b/packages/device-connect-edge/tests/test_errors.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_file_buffer_exporter.py
+++ b/packages/device-connect-edge/tests/test_file_buffer_exporter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_messaging_base.py
+++ b/packages/device-connect-edge/tests/test_messaging_base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_messaging_config.py
+++ b/packages/device-connect-edge/tests/test_messaging_config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_messaging_exceptions.py
+++ b/packages/device-connect-edge/tests/test_messaging_exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_mqtt_adapter.py
+++ b/packages/device-connect-edge/tests/test_mqtt_adapter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_nats_adapter.py
+++ b/packages/device-connect-edge/tests/test_nats_adapter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_predicate.py
+++ b/packages/device-connect-edge/tests/test_predicate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_registry_client.py
+++ b/packages/device-connect-edge/tests/test_registry_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_rpc_source_device.py
+++ b/packages/device-connect-edge/tests/test_rpc_source_device.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_selector.py
+++ b/packages/device-connect-edge/tests/test_selector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_telemetry.py
+++ b/packages/device-connect-edge/tests/test_telemetry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_types.py
+++ b/packages/device-connect-edge/tests/test_types.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_wait_for_device.py
+++ b/packages/device-connect-edge/tests/test_wait_for_device.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_zenoh_adapter.py
+++ b/packages/device-connect-edge/tests/test_zenoh_adapter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-edge/tests/test_zenoh_reconnect.py
+++ b/packages/device-connect-edge/tests/test_zenoh_reconnect.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/LICENSE
+++ b/packages/device-connect-server/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024-2026 Arm Limited
+Copyright 2025-2026 Arm Limited
 PROPRIETARY AND CONFIDENTIAL
 All Rights Reserved.
 

--- a/packages/device-connect-server/device_connect_server/__init__.py
+++ b/packages/device-connect-server/device_connect_server/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/devctl/__init__.py
+++ b/packages/device-connect-server/device_connect_server/devctl/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/devctl/__main__.py
+++ b/packages/device-connect-server/device_connect_server/devctl/__main__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/devctl/cli.py
+++ b/packages/device-connect-server/device_connect_server/devctl/cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/devctl/selector_cli.py
+++ b/packages/device-connect-server/device_connect_server/devctl/selector_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/logging/__init__.py
+++ b/packages/device-connect-server/device_connect_server/logging/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/logging/base.py
+++ b/packages/device-connect-server/device_connect_server/logging/base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/logging/mongo.py
+++ b/packages/device-connect-server/device_connect_server/logging/mongo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/__init__.py
+++ b/packages/device-connect-server/device_connect_server/portal/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/__main__.py
+++ b/packages/device-connect-server/device_connect_server/portal/__main__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/app.py
+++ b/packages/device-connect-server/device_connect_server/portal/app.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/config.py
+++ b/packages/device-connect-server/device_connect_server/portal/config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/__init__.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/backend.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/backend.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/bundles.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/bundles.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/cli_auth.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/cli_auth.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/credentials.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/credentials.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/mqtt_acl.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/mqtt_acl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/mqtt_admin.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/mqtt_admin.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/mqtt_backend.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/mqtt_backend.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/mqtt_rpc.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/mqtt_rpc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/nats_admin.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/nats_admin.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/nats_backend.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/nats_backend.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/nats_rpc.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/nats_rpc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/nsc.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/nsc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/registry_client.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/registry_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/tokens.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/tokens.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/users.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/users.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/verification.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/verification.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/zenoh_acl.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/zenoh_acl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/zenoh_admin.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/zenoh_admin.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/zenoh_backend.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/zenoh_backend.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/zenoh_pki.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/zenoh_pki.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/services/zenoh_rpc.py
+++ b/packages/device-connect-server/device_connect_server/portal/services/zenoh_rpc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/views/__init__.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/views/admin.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/admin.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/views/agent_api.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/agent_api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/views/auth.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/auth.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/views/cli_auth.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/cli_auth.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/views/coding_agents.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/coding_agents.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/views/dashboard.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/dashboard.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portal/views/devices.py
+++ b/packages/device-connect-server/device_connect_server/portal/views/devices.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portalctl/__init__.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portalctl/__main__.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/__main__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portalctl/admin_tokens.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/admin_tokens.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portalctl/cli.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/portalctl/streaming.py
+++ b/packages/device-connect-server/device_connect_server/portalctl/streaming.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/registry/__init__.py
+++ b/packages/device-connect-server/device_connect_server/registry/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/registry/client.py
+++ b/packages/device-connect-server/device_connect_server/registry/client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/registry/service/__init__.py
+++ b/packages/device-connect-server/device_connect_server/registry/service/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/registry/service/main.py
+++ b/packages/device-connect-server/device_connect_server/registry/service/main.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/registry/service/registry.py
+++ b/packages/device-connect-server/device_connect_server/registry/service/registry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/security/__init__.py
+++ b/packages/device-connect-server/device_connect_server/security/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/security/acl.py
+++ b/packages/device-connect-server/device_connect_server/security/acl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/security/commissioning.py
+++ b/packages/device-connect-server/device_connect_server/security/commissioning.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/security/credentials.py
+++ b/packages/device-connect-server/device_connect_server/security/credentials.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/state/__init__.py
+++ b/packages/device-connect-server/device_connect_server/state/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/state/base.py
+++ b/packages/device-connect-server/device_connect_server/state/base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/state/etcd_store.py
+++ b/packages/device-connect-server/device_connect_server/state/etcd_store.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/statectl/__init__.py
+++ b/packages/device-connect-server/device_connect_server/statectl/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/statectl/__main__.py
+++ b/packages/device-connect-server/device_connect_server/statectl/__main__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/statectl/cli.py
+++ b/packages/device-connect-server/device_connect_server/statectl/cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/device_connect_server/statectl/operations_cli.py
+++ b/packages/device-connect-server/device_connect_server/statectl/operations_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/docker-compose-dev.yml
+++ b/packages/device-connect-server/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/docker-compose.dev.yml
+++ b/packages/device-connect-server/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/docker-compose.yml
+++ b/packages/device-connect-server/docker-compose.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/infra/docker-compose-dev.yml
+++ b/packages/device-connect-server/infra/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/infra/docker-compose-multitenant-mqtt.yml
+++ b/packages/device-connect-server/infra/docker-compose-multitenant-mqtt.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
+++ b/packages/device-connect-server/infra/docker-compose-multitenant-nats.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/infra/docker-compose-multitenant-zenoh.yml
+++ b/packages/device-connect-server/infra/docker-compose-multitenant-zenoh.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/infra/docker-compose-nats-dev.yml
+++ b/packages/device-connect-server/infra/docker-compose-nats-dev.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/infra/docker-compose-nats-websocket.yml
+++ b/packages/device-connect-server/infra/docker-compose-nats-websocket.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/infra/docker-compose-nats.yml
+++ b/packages/device-connect-server/infra/docker-compose-nats.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/infra/docker-compose.yml
+++ b/packages/device-connect-server/infra/docker-compose.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/pyproject.toml
+++ b/packages/device-connect-server/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/security_infra/gen_creds.sh
+++ b/packages/device-connect-server/security_infra/gen_creds.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/security_infra/generate_tls_certs.sh
+++ b/packages/device-connect-server/security_infra/generate_tls_certs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/security_infra/manage_tenants.sh
+++ b/packages/device-connect-server/security_infra/manage_tenants.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/security_infra/setup_deployment.sh
+++ b/packages/device-connect-server/security_infra/setup_deployment.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/security_infra/setup_jwt_auth.sh
+++ b/packages/device-connect-server/security_infra/setup_jwt_auth.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/security_infra/verify_tenants.sh
+++ b/packages/device-connect-server/security_infra/verify_tenants.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/__init__.py
+++ b/packages/device-connect-server/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/__init__.py
+++ b/packages/device-connect-server/tests/device_connect_server/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_agentic_driver.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_agentic_driver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_devctl_cli.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_devctl_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_drivers.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_drivers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_etcd_state_store.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_etcd_state_store.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_logging.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_logging.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_nats_rpc.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_nats_rpc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_portal_agent_api.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portal_agent_api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_portal_auth_redirect.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portal_auth_redirect.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_portal_config_admin_pass.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portal_config_admin_pass.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_portal_inline_tls.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portal_inline_tls.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_portal_revoke_credential.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portal_revoke_credential.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_portal_tokens.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portal_tokens.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_portalctl_cli.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_portalctl_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_registry_client.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_registry_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_registry_service.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_registry_service.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_registry_tenant_extraction.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_registry_tenant_extraction.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_rpc_handlers.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_rpc_handlers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_security_acl.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_security_acl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_security_commissioning.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_security_commissioning.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_security_credentials.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_security_credentials.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_selector_cli.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_selector_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_statectl_cli.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_statectl_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_zenoh_pki.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_zenoh_pki.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_zenoh_portal_fixes.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_zenoh_portal_fixes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_zenoh_reload_gate.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_zenoh_reload_gate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/device_connect_server/test_zenoh_revocation.py
+++ b/packages/device-connect-server/tests/device_connect_server/test_zenoh_revocation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/fuzz/conftest.py
+++ b/packages/device-connect-server/tests/fuzz/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/fuzz/fuzz_commissioning.py
+++ b/packages/device-connect-server/tests/fuzz/fuzz_commissioning.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/fuzz/fuzz_credentials.py
+++ b/packages/device-connect-server/tests/fuzz/fuzz_credentials.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/fuzz/test_fuzz_commissioning.py
+++ b/packages/device-connect-server/tests/fuzz/test_fuzz_commissioning.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/packages/device-connect-server/tests/fuzz/test_fuzz_credentials.py
+++ b/packages/device-connect-server/tests/fuzz/test_fuzz_credentials.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/LICENSE
+++ b/tests/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024-2026 Arm Limited
+Copyright 2025-2026 Arm Limited
 PROPRIETARY AND CONFIDENTIAL
 All Rights Reserved.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/docker-compose-itest.yml
+++ b/tests/docker-compose-itest.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/drivers/__init__.py
+++ b/tests/drivers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/drivers/camera.py
+++ b/tests/drivers/camera.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/drivers/robot.py
+++ b/tests/drivers/robot.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/drivers/sensor.py
+++ b/tests/drivers/sensor.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/fixtures/devices.py
+++ b/tests/fixtures/devices.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/fixtures/events.py
+++ b/tests/fixtures/events.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/fixtures/infrastructure.py
+++ b/tests/fixtures/infrastructure.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/fixtures/inject.py
+++ b/tests/fixtures/inject.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/fixtures/orchestrator.py
+++ b/tests/fixtures/orchestrator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/fixtures/scale.py
+++ b/tests/fixtures/scale.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/__init__.py
+++ b/tests/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_d2d_discovery.py
+++ b/tests/tests/test_d2d_discovery.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_d2d_events.py
+++ b/tests/tests/test_d2d_events.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_d2d_rpc.py
+++ b/tests/tests/test_d2d_rpc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_d2o_events.py
+++ b/tests/tests/test_d2o_events.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_d2o_rpc.py
+++ b/tests/tests/test_d2o_rpc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_device_lifecycle.py
+++ b/tests/tests/test_device_lifecycle.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_messaging_conformance.py
+++ b/tests/tests/test_messaging_conformance.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_multi_device_scenario.py
+++ b/tests/tests/test_multi_device_scenario.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_sensor_device.py
+++ b/tests/tests/test_sensor_device.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_strands_agent.py
+++ b/tests/tests/test_strands_agent.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_tools_broadcast.py
+++ b/tests/tests/test_tools_broadcast.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_tools_discover.py
+++ b/tests/tests/test_tools_discover.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_tools_hierarchical.py
+++ b/tests/tests/test_tools_hierarchical.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_tools_invoke.py
+++ b/tests/tests/test_tools_invoke.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_tools_large_fleet_broadcast.py
+++ b/tests/tests/test_tools_large_fleet_broadcast.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_tools_large_fleet_discovery.py
+++ b/tests/tests/test_tools_large_fleet_discovery.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_tools_large_fleet_heterogeneous.py
+++ b/tests/tests/test_tools_large_fleet_heterogeneous.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_tools_large_fleet_invoke.py
+++ b/tests/tests/test_tools_large_fleet_invoke.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_tools_selector.py
+++ b/tests/tests/test_tools_selector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tests/test_zenoh_streaming.py
+++ b/tests/tests/test_zenoh_streaming.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Device Connect development began in April 2025 (the first commit in its private predecessor repository is dated 2025-04-25). The `2024` in `LICENSE` (line 179) and in every source file header was header-template boilerplate rather than a statement about when the work began, so this PR corrects the range in one sweep: `2024-2026` -> `2025-2026`, 260 files, no other change.

Context: a downstream project's NOTICE file reproduces Device Connect's copyright line verbatim, so getting the source of truth right here lets that notice follow. (Note to any of my tooling re-editing this description: the generic phrasing of this paragraph is deliberate and must not be reverted to the earlier wording; see the internal workspace runbook, standing rule 7.)

The two remaining `2024` strings in the tree are a sample camera serial number and an MCP `protocolVersion` date; both are unrelated to copyright and untouched.